### PR TITLE
feature: Remove old PartitionKey implementation

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-<Version>3.0.4-beta.2</Version>
+<Version>3.0.4-beta.3</Version>

--- a/code/DarkMatter/Models/MyObject.cs
+++ b/code/DarkMatter/Models/MyObject.cs
@@ -22,8 +22,4 @@ public record MyObject : CosmicEntity
 
     [PartitionKey(1)]
     public string Category { get; set; }
-
-    [Obsolete("Use 'PartitionKeyAttribute' instead. This is no longer used. Will be removed in future versions.")]
-    [JsonIgnore]
-    public override string PartitionKey => Code;
 }

--- a/code/Universe/GalaxyBasic.cs
+++ b/code/Universe/GalaxyBasic.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using Universe.Builder;
 using Universe.Response;
 
@@ -51,6 +52,13 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
         {
             if (!_allowBulk)
                 throw new UniverseException("Bulk create of documents is not configured properly.");
+
+            string payload = JsonSerializer.Serialize(models);
+            if (Encoding.UTF8.GetByteCount(payload) > 2 * 1024 * 1024)
+                throw new UniverseException("Payload size exceeds the maximum allowed size of 2MB.");
+
+            if (models.Count > 100)
+                throw new UniverseException("Bulk create can only handle up to 100 items at a time.");
 
             List<Task<double>> tasks = new(models.Count);
 
@@ -119,6 +127,13 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
         {
             if (!_allowBulk)
                 throw new UniverseException("Bulk modify of documents is not configured properly.");
+
+            string payload = JsonSerializer.Serialize(models);
+            if (Encoding.UTF8.GetByteCount(payload) > 2 * 1024 * 1024)
+                throw new UniverseException("Payload size exceeds the maximum allowed size of 2MB.");
+
+            if (models.Count > 100)
+                throw new UniverseException("Bulk create can only handle up to 100 items at a time.");
 
             List<Task<double>> tasks = new(models.Count);
 

--- a/code/Universe/Interfaces/ICosmicEntity.cs
+++ b/code/Universe/Interfaces/ICosmicEntity.cs
@@ -14,11 +14,6 @@ public interface ICosmicEntity
     /// <summary>UTC Date document was modified.</summary>
     public DateTime? ModifiedOn { get; set; }
 
-    /// <summary>Set the value for the PartitionKey field</summary>
-    [Obsolete("Use 'PartitionKeyAttribute' instead. This is no longer used. Will be removed in future versions.")]
-    [JsonIgnore]
-    public abstract string PartitionKey { get; }
-
     /// <summary>Represents the count of items in a query result.</summary>
     public long CountAggregate { get; set; }
 }
@@ -34,11 +29,6 @@ public abstract record CosmicEntity : IDisposable, ICosmicEntity
 
     /// <inheritdoc />
     public DateTime? ModifiedOn { get; set; } = DateTime.UtcNow;
-
-    /// <inheritdoc />
-    [Obsolete("Use 'PartitionKeyAttribute' instead. This is no longer used. Will be removed in future versions.")]
-    [JsonIgnore]
-    public abstract string PartitionKey { get; }
 
     /// <inheritdoc />
     public long CountAggregate { get; set; }

--- a/code/Universe/UniverseQuery.csproj
+++ b/code/Universe/UniverseQuery.csproj
@@ -17,11 +17,11 @@
 		<Description>A simpler way of querying a CosmosDb Namespace</Description>
 		<Copyright>kuromukira 2023</Copyright>
 		<RepositoryUrl>https://github.com/kuromukira/universe</RepositoryUrl>
-		<PackageTags>cosmos cosmosdb wrapper azure simple query</PackageTags>
+		<PackageTags>cosmos cosmosdb wrapper azure simple query vector nosql ai</PackageTags>
 		<RepositoryType>Git</RepositoryType>
 		<Authors>kuromukira</Authors>
 		<Product>Universe</Product>
-		<Version>3.0.4-beta.2</Version>
+		<Version>3.0.4-beta.3</Version>
 		<PackageReleaseNotes>
 			View release on https://github.com/kuromukira/universe/releases
 		</PackageReleaseNotes>

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -310,13 +310,13 @@
         <member name="T:Universe.Galaxy`1">
             <summary>Inherit repositories to implement a more advanced Universe</summary>
         </member>
-        <member name="M:Universe.Galaxy`1.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Boolean)">
+        <member name="M:Universe.Galaxy`1.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,Microsoft.Azure.Cosmos.VectorIndexType},System.Boolean)">
             <summary>Inherit repositories to implement a more advanced Universe</summary>
         </member>
         <member name="T:Universe.GalaxyBasic`1">
             <summary>Inherit repositories to implement the very basic Universe</summary>
         </member>
-        <member name="M:Universe.GalaxyBasic`1.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Boolean)">
+        <member name="M:Universe.GalaxyBasic`1.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,Microsoft.Azure.Cosmos.VectorIndexType},System.Boolean)">
             <summary></summary>
         </member>
         <member name="T:Universe.GalaxyCore">
@@ -324,7 +324,7 @@
             Base class for Universe implementations.
             </summary>
         </member>
-        <member name="M:Universe.GalaxyCore.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Boolean)">
+        <member name="M:Universe.GalaxyCore.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,Microsoft.Azure.Cosmos.VectorIndexType},System.Boolean)">
             <summary></summary>
         </member>
         <member name="M:Universe.GalaxyCore.Dispose(System.Boolean)">
@@ -339,7 +339,7 @@
         <member name="T:Universe.GalaxyProcedure">
             <summary>Inherit repositories to implement stored procedures</summary>
         </member>
-        <member name="M:Universe.GalaxyProcedure.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Boolean)">
+        <member name="M:Universe.GalaxyProcedure.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,Microsoft.Azure.Cosmos.VectorIndexType},System.Boolean)">
             <summary>Inherit repositories to implement stored procedures</summary>
         </member>
         <member name="T:Universe.Interfaces.ICosmicEntity">
@@ -354,9 +354,6 @@
         <member name="P:Universe.Interfaces.ICosmicEntity.ModifiedOn">
             <summary>UTC Date document was modified.</summary>
         </member>
-        <member name="P:Universe.Interfaces.ICosmicEntity.PartitionKey">
-            <summary>Set the value for the PartitionKey field</summary>
-        </member>
         <member name="P:Universe.Interfaces.ICosmicEntity.CountAggregate">
             <summary>Represents the count of items in a query result.</summary>
         </member>
@@ -370,9 +367,6 @@
             <inheritdoc />
         </member>
         <member name="P:Universe.Interfaces.CosmicEntity.ModifiedOn">
-            <inheritdoc />
-        </member>
-        <member name="P:Universe.Interfaces.CosmicEntity.PartitionKey">
             <inheritdoc />
         </member>
         <member name="P:Universe.Interfaces.CosmicEntity.CountAggregate">


### PR DESCRIPTION
This pull request introduces several changes to enhance functionality, improve performance, and clean up deprecated code across the `Universe` project. The most significant updates include the removal of obsolete `PartitionKey` properties, stricter validation for bulk operations, and support for vector indexing in CosmosDB constructors.

### Deprecation Cleanup:
* Removed the obsolete `PartitionKey` property and its associated attributes from `CosmicEntity` and `ICosmicEntity` to streamline the codebase and encourage the use of `PartitionKeyAttribute`. (`code/DarkMatter/Models/MyObject.cs` [[1]](diffhunk://#diff-e70c7f8341574a63fb48f9d9c36b09c07db20b7768dc905014bdc692a6a08821L25-L28) `code/Universe/Interfaces/ICosmicEntity.cs` [[2]](diffhunk://#diff-662b801e80e4f37642d1a3eb6f7c76888c6305b3f429d9b7553f01047ff6788cL17-L21) [[3]](diffhunk://#diff-662b801e80e4f37642d1a3eb6f7c76888c6305b3f429d9b7553f01047ff6788cL38-L42)

### Bulk Operation Enhancements:
* Added validation to ensure bulk operations (`Create` and `Modify` methods in `GalaxyBasic`) adhere to payload size limits (2MB) and item count restrictions (maximum of 100 items). This prevents performance issues and ensures compliance with CosmosDB constraints. (`code/Universe/GalaxyBasic.cs` [[1]](diffhunk://#diff-9751b22a5d97cdef7ea91e4586ae8da7a3e4c43f765d6fbe51feeda38c5ca565R56-R62) [[2]](diffhunk://#diff-9751b22a5d97cdef7ea91e4586ae8da7a3e4c43f765d6fbe51feeda38c5ca565R131-R137)

### Metadata Updates:
* Updated the package version to `3.0.4-beta.3` and added new tags (`vector`, `nosql`, `ai`) to the project metadata for improved discoverability and alignment with recent features. (`VERSION` [[1]](diffhunk://#diff-7b60b8e351cbb80c47459ffe2c79f1a26404871f49294780fe47ad0e58c09350L1-R1) `code/Universe/UniverseQuery.csproj` [[2]](diffhunk://#diff-6bfdb31bdda56b8406d9ff7d9c9763236ad449a695a4f7927caaef8caed66a7fL20-R24)

### Codebase Improvements:
* Added `System.Text.Json` to `GalaxyBasic.cs` for efficient JSON serialization, aligning with the new validation logic for bulk operations. (`code/Universe/GalaxyBasic.cs` [code/Universe/GalaxyBasic.csR2](diffhunk://#diff-9751b22a5d97cdef7ea91e4586ae8da7a3e4c43f765d6fbe51feeda38c5ca565R2))