### PR TITLE
bugfix: Remove Vector Index Policy setup

### DIFF
--- a/VECTORDISTANCE_USAGE.md
+++ b/VECTORDISTANCE_USAGE.md
@@ -12,6 +12,7 @@ The Universe library supports vector similarity search through the `Q.Operator.V
 2. **Vector format** - Values must be `float[]` arrays with finite numbers
 3. **Container setup** - Your Cosmos DB container must have vector indexing configured
 4. **No traditional sorting** - Cannot combine `VectorDistance` with regular `ORDER BY` clauses
+5. Ensure your container has a proper **Vector Index Policy** setup
 
 ## Generated Query Examples
 
@@ -24,13 +25,7 @@ MyRepoVector vectorGalaxy = new(
     client: cosmosClient,
     database: "test-database",
     container: "vector-container",
-    partitionKey: typeof(MyObjectVector).BuildPartitionKey(),
-    vectorPolicy: new Dictionary<string, VectorIndexType>
-    {
-        { nameof(MyObjectVector.DescriptionEmbedding), VectorIndexType.Flat },
-        { nameof(MyObjectVector.TitleEmbedding), VectorIndexType.Flat },
-        { nameof(MyObjectVector.CombinedEmbedding), VectorIndexType.Flat }
-    }
+    partitionKey: typeof(MyObjectVector).BuildPartitionKey()
 );
 ```
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-<Version>3.0.4-beta.3</Version>
+<Version>3.0.4-beta.4</Version>

--- a/code/DarkMatter/Program.cs
+++ b/code/DarkMatter/Program.cs
@@ -38,13 +38,7 @@ class Program
             client: cosmosClient,
             database: "test-database",
             container: "vector-container",
-            partitionKey: typeof(MyObjectVector).BuildPartitionKey(),
-            vectorPolicy: new Dictionary<string, VectorIndexType>
-            {
-                { nameof(MyObjectVector.DescriptionEmbedding), VectorIndexType.Flat },
-                { nameof(MyObjectVector.TitleEmbedding), VectorIndexType.QuantizedFlat },
-                { nameof(MyObjectVector.CombinedEmbedding), VectorIndexType.DiskANN }
-            }
+            partitionKey: typeof(MyObjectVector).BuildPartitionKey()
         );
 
         // Track the total request units spent

--- a/code/DarkMatter/Repository/MyRepoVector.cs
+++ b/code/DarkMatter/Repository/MyRepoVector.cs
@@ -5,10 +5,10 @@ using DarkMatter.Models;
 namespace DarkMatter.Repository
 {
 #if DEBUG
-    public class MyRepoVector(CosmosClient client, string database, string container, IReadOnlyList<string> partitionKey, IReadOnlyDictionary<string, VectorIndexType> vectorPolicy) : Galaxy<MyObjectVector>(client, database, container, partitionKey, vectorPolicy, true)
+    public class MyRepoVector(CosmosClient client, string database, string container, IReadOnlyList<string> partitionKey) : Galaxy<MyObjectVector>(client, database, container, partitionKey, true)
     {
 #else
-    public class MyRepoVector(CosmosClient client, string database, string container, IReadOnlyList<string> partitionKey, IReadOnlyDictionary<string, VectorIndexType> vectorPolicy) : Galaxy<MyObjectVector>(client, database, container, partitionKey, vectorPolicy)
+    public class MyRepoVector(CosmosClient client, string database, string container, IReadOnlyList<string> partitionKey) : Galaxy<MyObjectVector>(client, database, container, partitionKey)
     {
 #endif
     }

--- a/code/Universe/Galaxy.cs
+++ b/code/Universe/Galaxy.cs
@@ -9,8 +9,7 @@ public abstract class Galaxy<T>(
     string database,
     string container,
     IReadOnlyList<string> partitionKey,
-    IReadOnlyDictionary<string, VectorIndexType> vectorPolicy = null,
-    bool recordQueries = false) : GalaxyBasic<T>(client, database, container, partitionKey, vectorPolicy, recordQueries), IGalaxy<T> where T : class, ICosmicEntity
+    bool recordQueries = false) : GalaxyBasic<T>(client, database, container, partitionKey, recordQueries), IGalaxy<T> where T : class, ICosmicEntity
 {
     async Task<(Gravity, T)> IGalaxy<T>.Get(IList<Cluster> clusters, IList<string> columns)
         => await InternalGet<T>(clusters, columns);

--- a/code/Universe/GalaxyBasic.cs
+++ b/code/Universe/GalaxyBasic.cs
@@ -16,8 +16,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
         string database,
         string container,
         IReadOnlyList<string> partitionKey,
-        IReadOnlyDictionary<string, VectorIndexType> vectorPolicy = null,
-        bool recordQueries = false) : base(client, database, container, partitionKey, vectorPolicy, recordQueries) => _qBuilder = new(_recordQuery);
+        bool recordQueries = false) : base(client, database, container, partitionKey, recordQueries) => _qBuilder = new(_recordQuery);
 
     async Task<(Gravity, string)> IGalaxyBasic<T>.Create(T model)
     {

--- a/code/Universe/GalaxyCore.cs
+++ b/code/Universe/GalaxyCore.cs
@@ -11,7 +11,7 @@ public abstract class GalaxyCore : IDisposable
     internal readonly bool _allowBulk;
 
     /// <summary></summary>
-    protected GalaxyCore(CosmosClient client, string database, string container, IReadOnlyList<string> partitionKey, IReadOnlyDictionary<string, VectorIndexType> vectorPolicy = null, bool recordQueries = false)
+    protected GalaxyCore(CosmosClient client, string database, string container, IReadOnlyList<string> partitionKey, bool recordQueries = false)
     {
         if (string.IsNullOrWhiteSpace(container))
             throw new UniverseException("Container name is required");
@@ -22,19 +22,6 @@ public abstract class GalaxyCore : IDisposable
         client.CreateDatabaseIfNotExistsAsync(database).GetAwaiter().GetResult();
 
         ContainerProperties containerProps = new(container, partitionKey);
-
-        if (vectorPolicy is not null && vectorPolicy.Any())
-        {
-            IndexingPolicy policy = new();
-            foreach (var vp in vectorPolicy)
-                policy.VectorIndexes.Add(new VectorIndexPath
-                {
-                    Path = $"/{vp.Key}",
-                    Type = vp.Value
-                });
-
-            containerProps.IndexingPolicy = policy;
-        }
 
         _recordQuery = recordQueries;
         if (client.ClientOptions is not null)

--- a/code/Universe/GalaxyProcedures.cs
+++ b/code/Universe/GalaxyProcedures.cs
@@ -11,8 +11,7 @@ public abstract class GalaxyProcedure(
     string database,
     string container,
     IReadOnlyList<string> partitionKey,
-    IReadOnlyDictionary<string, VectorIndexType> vectorPolicy = null,
-    bool recordQueries = false) : GalaxyCore(client, database, container, partitionKey, vectorPolicy, recordQueries), IGalaxyProcedure
+    bool recordQueries = false) : GalaxyCore(client, database, container, partitionKey, recordQueries), IGalaxyProcedure
 {
     async Task<(Gravity g, T T)> IGalaxyProcedure.ExecSProc<T>(string procedureName, string partitionKey, params object[] parameters)
     {

--- a/code/Universe/UniverseQuery.csproj
+++ b/code/Universe/UniverseQuery.csproj
@@ -21,7 +21,7 @@
 		<RepositoryType>Git</RepositoryType>
 		<Authors>kuromukira</Authors>
 		<Product>Universe</Product>
-		<Version>3.0.4-beta.3</Version>
+		<Version>3.0.4-beta.4</Version>
 		<PackageReleaseNotes>
 			View release on https://github.com/kuromukira/universe/releases
 		</PackageReleaseNotes>

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -310,13 +310,13 @@
         <member name="T:Universe.Galaxy`1">
             <summary>Inherit repositories to implement a more advanced Universe</summary>
         </member>
-        <member name="M:Universe.Galaxy`1.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,Microsoft.Azure.Cosmos.VectorIndexType},System.Boolean)">
+        <member name="M:Universe.Galaxy`1.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Boolean)">
             <summary>Inherit repositories to implement a more advanced Universe</summary>
         </member>
         <member name="T:Universe.GalaxyBasic`1">
             <summary>Inherit repositories to implement the very basic Universe</summary>
         </member>
-        <member name="M:Universe.GalaxyBasic`1.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,Microsoft.Azure.Cosmos.VectorIndexType},System.Boolean)">
+        <member name="M:Universe.GalaxyBasic`1.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Boolean)">
             <summary></summary>
         </member>
         <member name="T:Universe.GalaxyCore">
@@ -324,7 +324,7 @@
             Base class for Universe implementations.
             </summary>
         </member>
-        <member name="M:Universe.GalaxyCore.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,Microsoft.Azure.Cosmos.VectorIndexType},System.Boolean)">
+        <member name="M:Universe.GalaxyCore.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Boolean)">
             <summary></summary>
         </member>
         <member name="M:Universe.GalaxyCore.Dispose(System.Boolean)">
@@ -339,7 +339,7 @@
         <member name="T:Universe.GalaxyProcedure">
             <summary>Inherit repositories to implement stored procedures</summary>
         </member>
-        <member name="M:Universe.GalaxyProcedure.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Collections.Generic.IReadOnlyDictionary{System.String,Microsoft.Azure.Cosmos.VectorIndexType},System.Boolean)">
+        <member name="M:Universe.GalaxyProcedure.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Boolean)">
             <summary>Inherit repositories to implement stored procedures</summary>
         </member>
         <member name="T:Universe.Interfaces.ICosmicEntity">


### PR DESCRIPTION
This pull request simplifies the `Universe` library by removing the `VectorIndexPolicy` feature from various classes and constructors. This change impacts how vector indexing is configured and used, streamlining the codebase and reducing complexity. Additionally, the version of the library has been incremented to `3.0.4-beta.4`.

### Removal of `VectorIndexPolicy` feature:

* **Documentation Update**: Added a note in `VECTORDISTANCE_USAGE.md` to ensure containers have a proper **Vector Index Policy** setup, reflecting the removal of inline vector policy configuration.
* **Constructor Changes**:
  - Removed `vectorPolicy` parameter from constructors in `Galaxy`, `GalaxyBasic`, `GalaxyCore`, and `GalaxyProcedure` classes, simplifying their signatures. [[1]](diffhunk://#diff-def4394b1561082f6c0b28af2ab1e126138d7959428fd0691f95edc1f5e70150L12-R12) [[2]](diffhunk://#diff-9751b22a5d97cdef7ea91e4586ae8da7a3e4c43f765d6fbe51feeda38c5ca565L19-R19) [[3]](diffhunk://#diff-49f8ad680fc9143509835eefbef7c84d3501ba7dd9a723072b262d8d17b9a80eL14-R14) [[4]](diffhunk://#diff-56039a21b56bedb6d0813826f860170b50dd0e8417a2b846becec2d248401fccL14-R14)
  - Updated `GalaxyCore` constructor to remove logic for applying `VectorIndexPolicy` to container properties.

### Codebase Updates Reflecting Feature Removal:

* **Repository Class Updates**: Refactored `MyRepoVector` class to remove the `vectorPolicy` parameter in its constructor.
* **Sample Code Adjustments**: Updated example code in `Program.cs` and `VECTORDISTANCE_USAGE.md` to remove `vectorPolicy` usage. [[1]](diffhunk://#diff-20dc0f8388335b40f5bd04238a852a52038bf76a64379d3754bf54ad769dbb9bL41-R41) [[2]](diffhunk://#diff-7eee5f4bb9ab2ac9218922d06c7807d53ca2cae4163bd1fd014a1aafde2dcb51L27-R28)

### Version Increment:

* **Version Update**: Incremented library version to `3.0.4-beta.4` in `VERSION` and `UniverseQuery.csproj`. [[1]](diffhunk://#diff-7b60b8e351cbb80c47459ffe2c79f1a26404871f49294780fe47ad0e58c09350L1-R1) [[2]](diffhunk://#diff-6bfdb31bdda56b8406d9ff7d9c9763236ad449a695a4f7927caaef8caed66a7fL24-R24)

### XML Documentation Changes:

* **Documentation Updates**: Updated `UniverseQuery.xml` to reflect the removal of `vectorPolicy` from constructors in `Galaxy`, `GalaxyBasic`, `GalaxyCore`, and `GalaxyProcedure`. [[1]](diffhunk://#diff-3d1b47123005be8ba727c3fd93b673613d91eea8000103b836007b39baa0fedcL313-R327) [[2]](diffhunk://#diff-3d1b47123005be8ba727c3fd93b673613d91eea8000103b836007b39baa0fedcL342-R342)