### PR TITLE
bugfix: Handling null sorting and weighting sorting for spatial queries

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-<Version>3.0.5-beta.1</Version>
+<Version>3.0.5-beta.2</Version>

--- a/code/Universe/Builder/QueryBuilder.cs
+++ b/code/Universe/Builder/QueryBuilder.cs
@@ -11,7 +11,7 @@ internal class UniverseBuilder(bool recordQueries)
         if (columnOptions is not null)
         {
             if (columnOptions.Value.Names is not null && columnOptions.Value.Names.Count > 0)
-                columnsInQuery = string.Join(", ", columnOptions.Value.Names.Select(c => $"c.{c}").ToList());
+                columnsInQuery = string.Join(", ", columnOptions.Value.Names.Select(c => $"c.{c}"));
 
             if (columnOptions.Value.Top > 0)
                 columnsInQuery = $"TOP {columnOptions.Value.Top} {columnsInQuery}";
@@ -77,7 +77,7 @@ internal class UniverseBuilder(bool recordQueries)
 
         // Update Columns Builder with Group By
         if (columnsInQuery.Contains('*') && groups is not null && groups.Any())
-            _ = columnsInQuery.Replace("*", string.Join(", ", groups.Select(c => $"c.{c}").ToList()));
+            columnsInQuery = columnsInQuery.Replace("*", string.Join(", ", groups.Select(c => $"c.{c}")));
 
         StringBuilder queryBuilder = new($"SELECT {columnsInQuery} FROM c");
 
@@ -95,7 +95,7 @@ internal class UniverseBuilder(bool recordQueries)
                 if (cluster.Catalysts.Any(c => c.RuleViolations().Any()))
                 {
                     List<IEnumerable<string>> violationsPerCatalyst = [.. cluster.Catalysts.Select(c => c.RuleViolations())];
-                    List<string> violations = [.. violationsPerCatalyst.SelectMany(v => v).ToList().Distinct()];
+                    List<string> violations = [.. violationsPerCatalyst.SelectMany(v => v).Distinct()];
                     throw new UniverseException(string.Join(Environment.NewLine, violations));
                 }
 
@@ -104,7 +104,7 @@ internal class UniverseBuilder(bool recordQueries)
                     throw new UniverseException("Each Catalyst in a Cluster must have a unique combination of Column and Operator.");
 
                 // ColumnOptions dependency check for VectorDistance
-                if (cluster.Catalysts.Any(c => c.Operator is Q.Operator.VectorDistance && columnOptions.GetValueOrDefault().Top <= 0))
+                if (cluster.Catalysts.Any(c => c.Operator is Q.Operator.VectorDistance) && (columnOptions == null || columnOptions.GetValueOrDefault().Top <= 0))
                     throw new UniverseException("ColumnOptions that specify a top value must be provided when using VectorDistance operator.");
 
                 // Skip if all catalysts are of VectorDistance operator
@@ -139,7 +139,7 @@ internal class UniverseBuilder(bool recordQueries)
                 throw new UniverseException("Sorting scalar fields is not supported in the presence of the VectorDistance operator.");
 
             queryBuilder.Append($" ORDER BY c.{sorting[0].Column} {sorting[0].Direction.Value()}");
-            foreach (Sorting.Option sort in sorting.Where(s => s.Column != sorting[0].Column).ToList())
+            foreach (Sorting.Option sort in sorting.Where(s => s.Column != sorting[0].Column))
                 queryBuilder.Append($", c.{sort.Column} {sort.Direction.Value()}");
         }
         else if (clusters is not null && clusters.Any(c => c.Catalysts.Any(cat => cat.Operator is Q.Operator.VectorDistance or Q.Operator.FTScore)))
@@ -151,18 +151,21 @@ internal class UniverseBuilder(bool recordQueries)
                 queryBuilder.Append(" ORDER BY RANK RRF(");
                 queryBuilder.Append(string.Join(", ", rankCatalysts.Select(c => $"{c.Operator.Value()}(c.{c.Column}, @{c.ParameterName()})")));
 
-                if (sorting is not null && sorting.Any(s => s.Direction is Sorting.Direction.WEIGHTED))
+                if (sorting is not null && sorting.Count(s => s.Direction is Sorting.Direction.WEIGHTED) > 1)
                     throw new UniverseException("Only one WEIGHT option is allowed.");
 
-                foreach (Sorting.Option sort in sorting.Where(s => s.Direction is Sorting.Direction.WEIGHTED).ToList())
+                if (sorting is not null)
                 {
-                    string weightValue = sort.Column;
-                    if (!weightValue.StartsWith('['))
-                        weightValue = $"[{weightValue}";
-                    if (!weightValue.EndsWith(']'))
-                        weightValue = $"{weightValue}]";
+                    foreach (Sorting.Option sort in sorting.Where(s => s.Direction is Sorting.Direction.WEIGHTED))
+                    {
+                        string weightValue = sort.Column;
+                        if (!weightValue.StartsWith('['))
+                            weightValue = $"[{weightValue}";
+                        if (!weightValue.EndsWith(']'))
+                            weightValue = $"{weightValue}]";
 
-                    queryBuilder.Append($", {weightValue}");
+                        queryBuilder.Append($", {weightValue}");
+                    }
                 }
 
                 queryBuilder.Append(')');
@@ -181,7 +184,7 @@ internal class UniverseBuilder(bool recordQueries)
         if (groups is not null && groups.Any())
         {
             queryBuilder.Append($" GROUP BY c.{groups[0]}");
-            foreach (string group in groups.Where(g => g != groups[0]).ToList())
+            foreach (string group in groups.Where(g => g != groups[0]))
                 queryBuilder.Append($", c.{group}");
         }
 
@@ -198,7 +201,7 @@ internal class UniverseBuilder(bool recordQueries)
         return query;
     }
 
-    internal string WhereClauseBuilder(Catalyst catalyst) => catalyst.Operator switch
+    internal static string WhereClauseBuilder(Catalyst catalyst) => catalyst.Operator switch
     {
         Q.Operator.In or
         Q.Operator.NotIn => $"{catalyst.Operator.Value()}(c.{catalyst.Column}, @{catalyst.ParameterName()})",

--- a/code/Universe/UniverseQuery.csproj
+++ b/code/Universe/UniverseQuery.csproj
@@ -21,7 +21,7 @@
 		<RepositoryType>Git</RepositoryType>
 		<Authors>kuromukira</Authors>
 		<Product>Universe</Product>
-		<Version>3.0.5-beta.1</Version>
+		<Version>3.0.5-beta.2</Version>
 		<PackageReleaseNotes>
 			View release on
 			https://github.com/kuromukira/universe/releases/tag/untagged-cdcf4202c2656450c07b


### PR DESCRIPTION
This pull request includes several updates to the `QueryBuilder` logic and minor version changes in the `VERSION` and project files. The most significant changes focus on code simplification, improving maintainability, and ensuring stricter validations in query-building logic.

### QueryBuilder Improvements:

* Removed unnecessary `.ToList()` calls in LINQ expressions to reduce overhead and improve performance in `CreateQuery`. [[1]](diffhunk://#diff-ce388b7b33b744a2ee51e5f7feb10781a1813d3a7d506fc963b531a8eed5f3d7L14-R14) [[2]](diffhunk://#diff-ce388b7b33b744a2ee51e5f7feb10781a1813d3a7d506fc963b531a8eed5f3d7L80-R80) [[3]](diffhunk://#diff-ce388b7b33b744a2ee51e5f7feb10781a1813d3a7d506fc963b531a8eed5f3d7L98-R98) [[4]](diffhunk://#diff-ce388b7b33b744a2ee51e5f7feb10781a1813d3a7d506fc963b531a8eed5f3d7L142-R142) [[5]](diffhunk://#diff-ce388b7b33b744a2ee51e5f7feb10781a1813d3a7d506fc963b531a8eed5f3d7L154-R159) [[6]](diffhunk://#diff-ce388b7b33b744a2ee51e5f7feb10781a1813d3a7d506fc963b531a8eed5f3d7L184-R187)
* Added stricter validation for `Sorting.Direction.WEIGHTED`, ensuring only one weighted option is allowed in queries.
* Refactored `WhereClauseBuilder` to be a static method, aligning with its stateless behavior.

### Version Updates:

* Updated the version in `VERSION` and `UniverseQuery.csproj` files from `3.0.5-beta.1` to `3.0.5-beta.2` to reflect the new release. [[1]](diffhunk://#diff-7b60b8e351cbb80c47459ffe2c79f1a26404871f49294780fe47ad0e58c09350L1-R1) [[2]](diffhunk://#diff-6bfdb31bdda56b8406d9ff7d9c9763236ad449a695a4f7927caaef8caed66a7fL24-R24)