### PR TITLE
feature: Add support for JOIN

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-<Version>3.0.5-beta.6</Version>
+<Version>3.0.5-beta.7</Version>

--- a/code/Universe/Builder/Options/ColumnOptions.cs
+++ b/code/Universe/Builder/Options/ColumnOptions.cs
@@ -8,8 +8,10 @@
 ///         List of aggregates to be applied to the query.
 ///         If aggregates are specified, the query will be grouped by the <paramref name="Names"/> columns.
 /// </param>
+/// <param name="Join">Options for joining a sub-collection.</param>
 public record struct ColumnOptions(
     IList<string> Names,
     bool IsDistinct = false,
     int Top = 0,
-    IEnumerable<AggregationOption> Aggregates = null);
+    IEnumerable<AggregationOption> Aggregates = null,
+    JoinOptions Join = null);

--- a/code/Universe/Builder/Options/JoinOptions.cs
+++ b/code/Universe/Builder/Options/JoinOptions.cs
@@ -1,0 +1,14 @@
+namespace Universe.Builder.Options;
+
+/// <summary>
+/// Options for joining tables.
+/// </summary>
+/// <param name="Alias">The alias for the sub-collection.</param>
+/// <param name="ArrayPath">The path to the array sub-collection.</param>
+/// <param name="Columns">The columns to include in the join.</param>
+/// <param name="Aggregates">The aggregation options for the join.</param>
+public record JoinOptions(
+    string Alias,
+    string ArrayPath,
+    IList<string> Columns,
+    IEnumerable<AggregationOption> Aggregates = null);

--- a/code/Universe/Builder/Options/Parameters.cs
+++ b/code/Universe/Builder/Options/Parameters.cs
@@ -9,12 +9,19 @@ namespace Universe.Builder.Options;
 /// <param name="Value">Value for the where clause associated with the Column</param>
 /// <param name="Where">Where operator (eg AND / OR)</param>
 /// <param name="Operator">Boolean expression operator</param>
+/// <param name="Alias">Alias for the collection containing the column. Default is 'c'</param>
 public readonly record struct Catalyst(
     string Column,
     object Value = null,
     Q.Where Where = Q.Where.And,
-    Q.Operator Operator = Q.Operator.Eq)
+    Q.Operator Operator = Q.Operator.Eq,
+    string Alias = "c")
 {
+    /// <summary>
+    /// Unique identifier for the catalyst, used to differentiate between multiple catalysts in a query.
+    /// </summary>
+    public string CatalystId { get; init; } = Guid.CreateVersion7().ToString().Replace("-", string.Empty);
+    
     /// <summary>Creates a list of rule violations when creating a CosmosDb query catalyst</summary>
     public IEnumerable<string> RuleViolations()
     {
@@ -85,5 +92,5 @@ public readonly record struct Catalyst(
 public static class CatalystExtension
 {
     /// <summary></summary>
-    public static string ParameterName(this Catalyst catalyst) => Regex.Replace(catalyst.Column, "[^\\w\\d]", string.Empty);
+    public static string ParameterName(this Catalyst catalyst) => $"{Regex.Replace(catalyst.Column, "[^\\w\\d]", string.Empty)}{catalyst.CatalystId}";
 }

--- a/code/Universe/Builder/Options/QueryOptions.cs
+++ b/code/Universe/Builder/Options/QueryOptions.cs
@@ -163,10 +163,10 @@ public static class AggregateExtension
     public static string Value(this Q.Aggregate aggregate) => aggregate switch
     {
         Q.Aggregate.Count => $"COUNT(1) AS {nameof(ICosmicEntity.CountAggregate)}",
-        Q.Aggregate.Sum => "SUM(c.{0}) AS {0}_Sum",
-        Q.Aggregate.Min => "MIN(c.{0}) AS {0}_Min",
-        Q.Aggregate.Max => "MAX(c.{0}) AS {0}_Max",
-        Q.Aggregate.Avg => "AVG(c.{0}) AS {0}_Avg",
+        Q.Aggregate.Sum => "SUM({0}.{1}) AS {1}_Sum",
+        Q.Aggregate.Min => "MIN({0}.{1}) AS {1}_Min",
+        Q.Aggregate.Max => "MAX({0}.{1}) AS {1}_Max",
+        Q.Aggregate.Avg => "AVG({0}.{1}) AS {1}_Avg",
         _ => throw new UniverseException("Unrecognized AGGREGATE keyword")
     };
 }

--- a/code/Universe/Builder/Options/SortingOptions.cs
+++ b/code/Universe/Builder/Options/SortingOptions.cs
@@ -17,7 +17,7 @@ public struct Sorting
     }
 
     /// <summary></summary>
-    public readonly record struct Option(string Column, Direction Direction = Direction.ASC);
+    public readonly record struct Option(string Column, Direction Direction = Direction.ASC, string Alias = "c");
 }
 
 /// <summary></summary>

--- a/code/Universe/Builder/QueryBuilder.cs
+++ b/code/Universe/Builder/QueryBuilder.cs
@@ -16,16 +16,16 @@ internal class UniverseBuilder(bool recordQueries)
             if (columnOptions.Value.Top > 0)
                 columnsInQuery = $"TOP {columnOptions.Value.Top} {columnsInQuery}";
 
-            if (columnOptions.Value.IsDistinct && columnOptions.Value.Names is not null && columnOptions.Value.Names.Count > 0)
+            if (columnOptions.Value is { IsDistinct: true, Names.Count: > 0 })
                 columnsInQuery = $"DISTINCT {columnsInQuery}";
 
-            if (columnOptions.Value.Aggregates is not null && columnOptions.Value.Aggregates.Count() > 0)
+            if (columnOptions.Value.Aggregates is not null && columnOptions.Value.Aggregates.Any())
             {
                 if (columnOptions.Value.Names is null || !columnOptions.Value.Names.Any())
                     throw new UniverseException("ColumnOption.Names must not be null or empty when using aggregates.");
 
                 groups ??= [];
-                groups = [.. groups.Concat(columnOptions.Value.Names ?? []).Distinct()];
+                groups = [.. groups.Concat(columnOptions.Value.Names.Select(n => $"c.{n}") ?? []).Distinct()];
 
                 if (columnOptions.Value.Aggregates.Any(ag => string.IsNullOrWhiteSpace(ag.Column)))
                     throw new UniverseException("Aggregate columns must not be null or empty.");
@@ -35,10 +35,10 @@ internal class UniverseBuilder(bool recordQueries)
                     string toAppend = aggregate.Aggregate switch
                     {
                         Q.Aggregate.Count => Q.Aggregate.Count.Value(),
-                        Q.Aggregate.Sum => string.Format(Q.Aggregate.Sum.Value(), aggregate.Column),
-                        Q.Aggregate.Min => string.Format(Q.Aggregate.Min.Value(), aggregate.Column),
-                        Q.Aggregate.Max => string.Format(Q.Aggregate.Max.Value(), aggregate.Column),
-                        Q.Aggregate.Avg => string.Format(Q.Aggregate.Avg.Value(), aggregate.Column),
+                        Q.Aggregate.Sum => string.Format(Q.Aggregate.Sum.Value(), "c", aggregate.Column),
+                        Q.Aggregate.Min => string.Format(Q.Aggregate.Min.Value(), "c", aggregate.Column),
+                        Q.Aggregate.Max => string.Format(Q.Aggregate.Max.Value(), "c", aggregate.Column),
+                        Q.Aggregate.Avg => string.Format(Q.Aggregate.Avg.Value(), "c", aggregate.Column),
                         _ => throw new UniverseException($"Unrecognized aggregate function: {aggregate.Aggregate}")
                     };
 
@@ -59,27 +59,69 @@ internal class UniverseBuilder(bool recordQueries)
         {
             List<Catalyst> vectorDistanceCatalysts = [.. clusters.SelectMany(cluster => cluster.Catalysts).Where(catalyst => catalyst.Operator is Q.Operator.VectorDistance)];
 
-            if (vectorDistanceCatalysts.Count > 1)
+            switch (vectorDistanceCatalysts.Count)
             {
-                foreach (Catalyst catalyst in vectorDistanceCatalysts)
-                    columnsInQuery += $", {catalyst.Operator.Value()}(c.{catalyst.Column}, @{catalyst.ParameterName()}) AS {catalyst.Column}Score";
-            }
-            else if (vectorDistanceCatalysts.Count == 1)
-            {
-                Catalyst catalyst = vectorDistanceCatalysts.First();
-                columnsInQuery += $", {catalyst.Operator.Value()}(c.{catalyst.Column}, @{catalyst.ParameterName()}) AS {catalyst.Column}Score";
+                case > 1:
+                    columnsInQuery = vectorDistanceCatalysts.Aggregate(columnsInQuery, (current, catalyst)
+                        => $"{current}, {catalyst.Operator.Value()}({catalyst.Alias}.{catalyst.Column}, @{catalyst.ParameterName()}) AS {catalyst.Column}Score");
+                    break;
+                case 1:
+                {
+                    Catalyst catalyst = vectorDistanceCatalysts.First();
+                    columnsInQuery += $", {catalyst.Operator.Value()}({catalyst.Alias}.{catalyst.Column}, @{catalyst.ParameterName()}) AS {catalyst.Column}Score";
+                    break;
+                }
             }
         }
 
-        // This error blocks code execution since this is not yet supported by CosmosDb
-        if (sorting is not null && sorting.Any() && groups is not null && groups.Any())
-            throw new UniverseException("ORDER BY is not supported in presence of GROUP BY");
-
         // Update Columns Builder with Group By
         if (columnsInQuery.Contains('*') && groups is not null && groups.Any())
-            columnsInQuery = columnsInQuery.Replace("*", string.Join(", ", groups.Select(c => $"c.{c}")));
+            columnsInQuery = columnsInQuery.Replace("*", string.Join(", ", groups));
 
         StringBuilder queryBuilder = new($"SELECT {columnsInQuery} FROM c");
+        
+        if (columnOptions?.Join is not null)
+        {
+            JoinOptions join = columnOptions.Value.Join;
+            queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{join.ArrayPath}");
+
+            // Add join columns to the select if specified
+            if (join.Columns?.Any() == true)
+            {
+                string joinColumns = string.Join(", ", join.Columns.Select(col => $"{join.Alias}.{col}"));
+                columnsInQuery = columnsInQuery == "*" ? $"c.*, {joinColumns}" : $"{columnsInQuery}, {joinColumns}";
+                queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{join.ArrayPath}");
+            }
+
+            // Handle join aggregates
+            if (join.Aggregates?.Any() == true)
+            {
+                groups ??= [];
+
+                foreach (AggregationOption aggregate in join.Aggregates)
+                {
+                    string toAppend = aggregate.Aggregate switch
+                    {
+                        Q.Aggregate.Count => Q.Aggregate.Count.Value(),
+                        Q.Aggregate.Sum => string.Format(Q.Aggregate.Sum.Value(), join.Alias, aggregate.Column),
+                        Q.Aggregate.Min => string.Format(Q.Aggregate.Min.Value(), join.Alias, aggregate.Column),
+                        Q.Aggregate.Max => string.Format(Q.Aggregate.Max.Value(), join.Alias, aggregate.Column),
+                        Q.Aggregate.Avg => string.Format(Q.Aggregate.Avg.Value(), join.Alias, aggregate.Column),
+                        _ => throw new UniverseException($"Unrecognized aggregate function: {aggregate.Aggregate}")
+                    };
+                    
+                    // Only add if not already present
+                    if (!columnsInQuery.Contains(toAppend))
+                        columnsInQuery = string.IsNullOrWhiteSpace(columnsInQuery) ? toAppend : $"{columnsInQuery}, {toAppend}";
+                }
+
+                // Add join columns to GROUP BY
+                if (join.Columns?.Any() == true)
+                    groups = [.. groups.Concat(join.Columns.Select(col => $"{join.Alias}.{col}"))];
+
+                queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{join.ArrayPath}");
+            }
+        }
 
         // Validate Clusters
         if (clusters is not null && clusters.Any(c => c.Catalysts is null || !c.Catalysts.Any()))
@@ -209,10 +251,14 @@ internal class UniverseBuilder(bool recordQueries)
         // Group By Builder
         if (groups is not null && groups.Any())
         {
-            queryBuilder.Append($" GROUP BY c.{groups[0]}");
+            queryBuilder.Append($" GROUP BY {groups[0]}");
             foreach (string group in groups.Where(g => g != groups[0]))
-                queryBuilder.Append($", c.{group}");
+                queryBuilder.Append($", {group}");
         }
+
+        // This error blocks code execution since this is not yet supported by CosmosDb
+        if (queryBuilder.ToString().Contains("ORDER BY") && groups is not null && groups.Any())
+            throw new UniverseException("ORDER BY is not supported in presence of GROUP BY");
 
         // Parameters Builder
         QueryDefinition query = new(queryBuilder.ToString());
@@ -227,23 +273,27 @@ internal class UniverseBuilder(bool recordQueries)
         return query;
     }
 
-    internal static string WhereClauseBuilder(Catalyst catalyst) => catalyst.Operator switch
+    private static string WhereClauseBuilder(Catalyst catalyst)
     {
-        Q.Operator.In or
-        Q.Operator.NotIn => $"{catalyst.Operator.Value()}(c.{catalyst.Column}, @{catalyst.ParameterName()})",
-        Q.Operator.Len => $"{catalyst.Operator.Value()}(c.{catalyst.Column}) = @{catalyst.ParameterName()}",
-        Q.Operator.Defined or
-        Q.Operator.NotDefined => $"{catalyst.Operator.Value()}(c.{catalyst.Column})",
-        Q.Operator.FTContains or
-        Q.Operator.NotFTContains or
-        Q.Operator.FTContainsAll or
-        Q.Operator.NotFTContainsAll or
-        Q.Operator.FTContainsAny or
-        Q.Operator.NotFTContainsAny => $"{catalyst.Operator.Value()}(c.{catalyst.Column}, @{catalyst.ParameterName()})",
-        _ => $"c.{catalyst.Column} {catalyst.Operator.Value()} @{catalyst.ParameterName()}",
-    };
+        string alias = catalyst.Alias ?? "c";
+        return catalyst.Operator switch
+        {
+            Q.Operator.In or
+                Q.Operator.NotIn => $"{catalyst.Operator.Value()}({alias}.{catalyst.Column}, @{catalyst.ParameterName()})",
+            Q.Operator.Len => $"{catalyst.Operator.Value()}({alias}.{catalyst.Column}) = @{catalyst.ParameterName()}",
+            Q.Operator.Defined or
+                Q.Operator.NotDefined => $"{catalyst.Operator.Value()}({alias}.{catalyst.Column})",
+            Q.Operator.FTContains or
+                Q.Operator.NotFTContains or
+                Q.Operator.FTContainsAll or
+                Q.Operator.NotFTContainsAll or
+                Q.Operator.FTContainsAny or
+                Q.Operator.NotFTContainsAny => $"{catalyst.Operator.Value()}({alias}.{catalyst.Column}, @{catalyst.ParameterName()})",
+            _ => $"{alias}.{catalyst.Column} {catalyst.Operator.Value()} @{catalyst.ParameterName()}",
+        };
+    }
 
-    async internal Task<(Gravity, T)> GetOneFromQuery<T>(Container container, QueryDefinition query)
+    internal async Task<(Gravity, T)> GetOneFromQuery<T>(Container container, QueryDefinition query)
     {
         using FeedIterator<T> queryResponse = container.GetItemQueryIterator<T>(query, requestOptions: new() { MaxItemCount = Q.Limits.MaxItems });
         if (queryResponse.HasMoreResults)
@@ -261,7 +311,7 @@ internal class UniverseBuilder(bool recordQueries)
         else return new(new(0, null), default);
     }
 
-    async internal Task<(Gravity, IList<T>)> GetListFromQuery<T>(Container container, QueryDefinition query)
+    internal async Task<(Gravity, IList<T>)> GetListFromQuery<T>(Container container, QueryDefinition query)
     {
         double requestCharge = 0;
         List<T> collection = [];

--- a/code/Universe/UniverseQuery.csproj
+++ b/code/Universe/UniverseQuery.csproj
@@ -21,7 +21,7 @@
 		<RepositoryType>Git</RepositoryType>
 		<Authors>kuromukira</Authors>
 		<Product>Universe</Product>
-		<Version>3.0.5-beta.6</Version>
+		<Version>3.0.5-beta.7</Version>
 		<PackageReleaseNotes>
 			View release on
 			https://github.com/kuromukira/universe/releases/tag/untagged-cdcf4202c2656450c07b
@@ -47,7 +47,6 @@
 
 	<ItemGroup>
 		<Folder Include="Exception\" />
-		<Folder Include="Options\" />
 		<Folder Include="Response\" />
 	</ItemGroup>
 


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the query-building functionality, focusing on improving support for joins, aliases, and aggregation handling. It also includes minor version updates. Below is a categorized summary of the most important changes:

### Enhancements to Query Building
* Added support for join options in `ColumnOptions` by introducing a new `JoinOptions` record, allowing for table joins with specified aliases, columns, and aggregates (`code/Universe/Builder/Options/ColumnOptions.cs`, `code/Universe/Builder/Options/JoinOptions.cs`) [[1]](diffhunk://#diff-7e7c98c8822ada4382ca62f10577df2c4ae26c355cdfffa0aa310d54500a568aR11-R17) [[2]](diffhunk://#diff-faa49f5e1cb431a30aedcab8f6203de9678ae1b561b5f362cc525a04289b4f95R1-R14).
* Updated `QueryBuilder` to handle join-specific logic, including adding join columns and aggregates to the query and updating the `GROUP BY` and `SELECT` clauses accordingly (`code/Universe/Builder/QueryBuilder.cs`) [[1]](diffhunk://#diff-ce388b7b33b744a2ee51e5f7feb10781a1813d3a7d506fc963b531a8eed5f3d7L19-R28) [[2]](diffhunk://#diff-ce388b7b33b744a2ee51e5f7feb10781a1813d3a7d506fc963b531a8eed5f3d7L212-R262).
* Enhanced `Catalyst` to include an `Alias` property for specifying the collection alias and a unique `CatalystId` for differentiating between multiple catalysts in a query (`code/Universe/Builder/Options/Parameters.cs`).

### Improved Aggregation and Alias Handling
* Modified aggregation functions to use aliases dynamically, improving flexibility in handling nested collections and joins (`code/Universe/Builder/Options/QueryOptions.cs`, `code/Universe/Builder/QueryBuilder.cs`) [[1]](diffhunk://#diff-923008a477cb13065c5be18efedaa0f4045c2f8f34988ed5b6d674daf0e77483L166-R169) [[2]](diffhunk://#diff-ce388b7b33b744a2ee51e5f7feb10781a1813d3a7d506fc963b531a8eed5f3d7L38-R41).
* Updated `SortingOptions` to include an `Alias` property for specifying the collection alias in sorting operations (`code/Universe/Builder/Options/SortingOptions.cs`).

### Bug Fixes and Code Refinements
* Fixed `GROUP BY` handling to avoid redundant `c.` prefixes and ensured compatibility with CosmosDB limitations (`code/Universe/Builder/QueryBuilder.cs`).
* Refactored `WhereClauseBuilder` to dynamically use the alias specified in `Catalyst` instead of hardcoding `c.` (`code/Universe/Builder/QueryBuilder.cs`).

### Version Updates
* Updated the project version from `3.0.5-beta.6` to `3.0.5-beta.7` in `VERSION` and `UniverseQuery.csproj` files (`VERSION`, `code/Universe/UniverseQuery.csproj`) [[1]](diffhunk://#diff-7b60b8e351cbb80c47459ffe2c79f1a26404871f49294780fe47ad0e58c09350L1-R1) [[2]](diffhunk://#diff-6bfdb31bdda56b8406d9ff7d9c9763236ad449a695a4f7927caaef8caed66a7fL24-R24).

These changes significantly improve the flexibility and functionality of the query-building system, particularly in scenarios involving complex joins and aggregation logic.