### PR TITLE
feature: Add new method to generate CosmosDb SQL query without execution

### DIFF
--- a/code/DarkMatter/Examples/Example12_QueryGeneration.cs
+++ b/code/DarkMatter/Examples/Example12_QueryGeneration.cs
@@ -1,0 +1,140 @@
+using DarkMatter.Models;
+using Universe.Builder.Options;
+using Universe.Extensions;
+using Universe.Interfaces;
+using Universe.Response;
+
+namespace DarkMatter.Examples;
+
+public class Example12_QueryGeneration(IGalaxy<MyObject> galaxy) : ExampleBase(galaxy)
+{
+    public override Task<double> RunAsync()
+    {
+        Console.WriteLine("\n=== EXAMPLE 12: Query Generation Without Execution ===\n");
+
+        // Example 1: Generate a simple query
+        Console.WriteLine("1. Generating Simple Query:");
+        Gravity simpleQuery = galaxy.GenerateQuery(
+            clusters:
+            [
+                new(Catalysts:
+                [
+                    new(nameof(MyObject.Code), "SAMPLE_CODE", Operator: Q.Operator.Like)
+                ])
+            ],
+            columnOptions: new(Names: [nameof(MyObject.id), nameof(MyObject.Name).ToLowerCamelCase()])
+        );
+
+        Console.WriteLine($"   Query: {simpleQuery.Query.Text}");
+        Console.WriteLine($"   Parameters: {string.Join(", ", simpleQuery.Query.Parameters.Select(p => $"{p.Item1}={p.Item2}"))}");
+        Console.WriteLine();
+
+        // Example 2: Generate a complex query with aggregations
+        Console.WriteLine("2. Generating Query with Aggregations:");
+        Gravity aggregateQuery = galaxy.GenerateQuery(
+            clusters:
+            [
+                new(Catalysts:
+                [
+                    new(nameof(MyObject.Links), "active", Operator: Q.Operator.In),
+                    new(nameof(MyObject.Name), Operator: Q.Operator.Defined, Where: Q.Where.And)
+                ])
+            ],
+            columnOptions: new(
+                Names:
+                [
+                    nameof(MyObject.Category).ToLowerCamelCase(),
+                    nameof(MyObject.Code).ToLowerCamelCase()
+                ],
+                Aggregates:
+                [
+                    new(nameof(MyObject.Price), Q.Aggregate.Sum),
+                    new(nameof(MyObject.Price), Q.Aggregate.Avg),
+                    new("*", Q.Aggregate.Count)
+                ],
+                IsDistinct: false,
+                Top: 50
+            ),
+            sorting:
+            [
+                new(nameof(MyObject.Category).ToLowerCamelCase(), Sorting.Direction.ASC)
+            ],
+            group: [nameof(MyObject.Category).ToLowerCamelCase(), nameof(MyObject.Code).ToLowerCamelCase()]
+        );
+
+        Console.WriteLine($"   Query: {aggregateQuery.Query.Text}");
+        Console.WriteLine($"   Parameters: {string.Join(", ", aggregateQuery.Query.Parameters.Select(p => $"{p.Item1}={p.Item2}"))}");
+        Console.WriteLine();
+
+        // Example 3: Generate a filtered query with sorting
+        Console.WriteLine("3. Generating Filtered Query with Sorting:");
+        Gravity filteredQuery = galaxy.GenerateQuery(
+            clusters:
+            [
+                new(Catalysts:
+                [
+                    new(nameof(MyObject.Price), 100.0, Operator: Q.Operator.Gte),
+                    new(nameof(MyObject.AddedOn), DateTime.Now.AddDays(-30), Operator: Q.Operator.Gte, Where: Q.Where.And)
+                ], Where: Q.Where.And),
+                new(Catalysts:
+                [
+                    new(nameof(MyObject.Description), Operator: Q.Operator.Defined)
+                ], Where: Q.Where.Or)
+            ],
+            columnOptions: new(
+                Names:
+                [
+                    nameof(MyObject.id),
+                    nameof(MyObject.Name).ToLowerCamelCase(),
+                    nameof(MyObject.Price).ToLowerCamelCase(),
+                    nameof(MyObject.Category).ToLowerCamelCase()
+                ],
+                IsDistinct: true,
+                Top: 25
+            ),
+            sorting:
+            [
+                new(nameof(MyObject.Price).ToLowerCamelCase(), Sorting.Direction.DESC),
+                new(nameof(MyObject.Name).ToLowerCamelCase(), Sorting.Direction.ASC)
+            ]
+        );
+
+        Console.WriteLine($"   Query: {filteredQuery.Query.Text}");
+        Console.WriteLine($"   Parameters: {string.Join(", ", filteredQuery.Query.Parameters.Select(p => $"{p.Item1}={p.Item2}"))}");
+        Console.WriteLine();
+
+        // Example 4: Generate a query with array joins
+        Console.WriteLine("4. Generating Query with Array Joins:");
+        Gravity joinQuery = galaxy.GenerateQuery(
+            clusters:
+            [
+                new(Catalysts:
+                [
+                    new(nameof(MyObject.Category), "Electronics", Operator: Q.Operator.Like)
+                ])
+            ],
+            columnOptions: new(
+                Names: [nameof(MyObject.id), nameof(MyObject.Name).ToLowerCamelCase()],
+                Join: new(
+                    ArrayPath: nameof(MyObject.Links).ToLowerCamelCase(),
+                    Alias: "link",
+                    Columns: ["url", "type"],
+                    Aggregates:
+                    [
+                        new("*", Q.Aggregate.Count)
+                    ]
+                ),
+                Top: 10
+            )
+        );
+
+        Console.WriteLine($"   Query: {joinQuery.Query.Text}");
+        Console.WriteLine($"   Parameters: {string.Join(", ", joinQuery.Query.Parameters.Select(p => $"{p.Item1}={p.Item2}"))}");
+        Console.WriteLine();
+
+        Console.WriteLine("Query generation completed successfully! All queries generated without execution.");
+        Console.WriteLine("You can now use these queries for debugging, logging, or manual execution.");
+
+        return Task.FromResult(0.0); // No RU consumed since no queries were executed
+    }
+}

--- a/code/DarkMatter/Program.cs
+++ b/code/DarkMatter/Program.cs
@@ -58,6 +58,7 @@ class Program
 		totalRu += await new Example9_VectorSearch(vectorGalaxy).RunAsync();
 		totalRu += await new Example10_FullTextSearch(galaxy).RunAsync();
 		totalRu += await new Example11_HybridVectorFullText(vectorGalaxy).RunAsync();
+		totalRu += await new Example12_QueryGeneration(galaxy).RunAsync();
 
 		// Display summary information
 		Console.WriteLine($"\nTotal RU spent across all examples: {totalRu}");

--- a/code/Universe/Galaxy.cs
+++ b/code/Universe/Galaxy.cs
@@ -91,4 +91,10 @@ public abstract class Galaxy<T>(
 			throw;
 		}
 	}
+
+	Gravity IGalaxy<T>.GenerateQuery(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> group)
+	{
+		QueryDefinition query = QBuilder.CreateQuery(clusters: clusters, columnOptions: columnOptions, sorting: sorting, groups: group);
+		return new(0, string.Empty, (query.QueryText, query.GetQueryParameters()));
+	}
 }

--- a/code/Universe/Interfaces/IGalaxy.cs
+++ b/code/Universe/Interfaces/IGalaxy.cs
@@ -35,4 +35,9 @@ public interface IGalaxy<T> : IGalaxyBasic<T> where T : ICosmicEntity
 	/// Get a paginated list from the database
 	/// </summary>
 	Task<(Gravity g, IList<S> T)> Paged<S>(Q.Page page, IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions = null, IReadOnlyList<Sorting.Option> sorting = null, IReadOnlyList<string> group = null) where S : ICosmicEntity;
+
+	/// <summary>
+	/// Generate SQL query without executing it
+	/// </summary>
+	Gravity GenerateQuery(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions = null, IReadOnlyList<Sorting.Option> sorting = null, IReadOnlyList<string> group = null);
 }

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -62,7 +62,7 @@
             </param>
             <param name="Join">Options for joining a sub-collection.</param>
         </member>
-        <member name="M:Universe.Builder.Options.ColumnOptions.#ctor(System.Collections.Generic.IList{System.String},System.Boolean,System.Int32,System.Collections.Generic.IEnumerable{Universe.Builder.Options.AggregationOption},Universe.Builder.Options.JoinOptions)">
+        <member name="M:Universe.Builder.Options.ColumnOptions.#ctor(System.Collections.Generic.IReadOnlyList{System.String},System.Boolean,System.Int32,System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.AggregationOption},Universe.Builder.Options.JoinOptions)">
             <summary></summary>
             <param name="Names">List of column names to be part of the query</param>
             <param name="IsDistinct">Adds DISTINCT in the generated query</param>
@@ -100,7 +100,7 @@
             <param name="Columns">The columns to include in the join.</param>
             <param name="Aggregates">The aggregation options for the join.</param>
         </member>
-        <member name="M:Universe.Builder.Options.JoinOptions.#ctor(System.String,System.String,System.Collections.Generic.IList{System.String},System.Collections.Generic.IEnumerable{Universe.Builder.Options.AggregationOption})">
+        <member name="M:Universe.Builder.Options.JoinOptions.#ctor(System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.AggregationOption})">
             <summary>
             Options for joining tables.
             </summary>
@@ -345,7 +345,7 @@
             <param name="Catalysts">Catalysts under one group / cluster</param>
             <param name="Where">Where operator (eg AND / OR)</param>
         </member>
-        <member name="M:Universe.Builder.Options.Cluster.#ctor(System.Collections.Generic.IList{Universe.Builder.Options.Catalyst},Universe.Builder.Options.Q.Where)">
+        <member name="M:Universe.Builder.Options.Cluster.#ctor(System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Catalyst},Universe.Builder.Options.Q.Where)">
             <summary>
             Clusters are group of Catalysts that are joined by a Where operator (eg AND / OR). This will divide the where clause into multiple groups.
             </summary>
@@ -474,34 +474,39 @@
         <member name="T:Universe.Interfaces.IGalaxy`1">
             <summary></summary>
         </member>
-        <member name="M:Universe.Interfaces.IGalaxy`1.Get(System.Collections.Generic.IList{Universe.Builder.Options.Cluster},System.Collections.Generic.IList{System.String})">
+        <member name="M:Universe.Interfaces.IGalaxy`1.Get(System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Cluster},System.Collections.Generic.IReadOnlyList{System.String})">
             <summary>
             Get one model from the database
             </summary>
         </member>
-        <member name="M:Universe.Interfaces.IGalaxy`1.Get``1(System.Collections.Generic.IList{Universe.Builder.Options.Cluster},System.Collections.Generic.IList{System.String})">
+        <member name="M:Universe.Interfaces.IGalaxy`1.Get``1(System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Cluster},System.Collections.Generic.IReadOnlyList{System.String})">
             <summary>
             Get one model from the database with a different type
             </summary>
         </member>
-        <member name="M:Universe.Interfaces.IGalaxy`1.List(System.Collections.Generic.IList{Universe.Builder.Options.Cluster},System.Nullable{Universe.Builder.Options.ColumnOptions},System.Collections.Generic.IList{Universe.Builder.Options.Sorting.Option},System.Collections.Generic.IList{System.String})">
+        <member name="M:Universe.Interfaces.IGalaxy`1.List(System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Cluster},System.Nullable{Universe.Builder.Options.ColumnOptions},System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Sorting.Option},System.Collections.Generic.IReadOnlyList{System.String})">
             <summary>
             Get list from the database
             </summary>
         </member>
-        <member name="M:Universe.Interfaces.IGalaxy`1.List``1(System.Collections.Generic.IList{Universe.Builder.Options.Cluster},System.Nullable{Universe.Builder.Options.ColumnOptions},System.Collections.Generic.IList{Universe.Builder.Options.Sorting.Option},System.Collections.Generic.IList{System.String})">
+        <member name="M:Universe.Interfaces.IGalaxy`1.List``1(System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Cluster},System.Nullable{Universe.Builder.Options.ColumnOptions},System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Sorting.Option},System.Collections.Generic.IReadOnlyList{System.String})">
             <summary>
             Get list from the database with a different type
             </summary>
         </member>
-        <member name="M:Universe.Interfaces.IGalaxy`1.Paged(Universe.Builder.Options.Q.Page,System.Collections.Generic.IList{Universe.Builder.Options.Cluster},System.Nullable{Universe.Builder.Options.ColumnOptions},System.Collections.Generic.IList{Universe.Builder.Options.Sorting.Option},System.Collections.Generic.IList{System.String})">
+        <member name="M:Universe.Interfaces.IGalaxy`1.Paged(Universe.Builder.Options.Q.Page,System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Cluster},System.Nullable{Universe.Builder.Options.ColumnOptions},System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Sorting.Option},System.Collections.Generic.IReadOnlyList{System.String})">
             <summary>
             Get a paginated list from the database
             </summary>
         </member>
-        <member name="M:Universe.Interfaces.IGalaxy`1.Paged``1(Universe.Builder.Options.Q.Page,System.Collections.Generic.IList{Universe.Builder.Options.Cluster},System.Nullable{Universe.Builder.Options.ColumnOptions},System.Collections.Generic.IList{Universe.Builder.Options.Sorting.Option},System.Collections.Generic.IList{System.String})">
+        <member name="M:Universe.Interfaces.IGalaxy`1.Paged``1(Universe.Builder.Options.Q.Page,System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Cluster},System.Nullable{Universe.Builder.Options.ColumnOptions},System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Sorting.Option},System.Collections.Generic.IReadOnlyList{System.String})">
             <summary>
             Get a paginated list from the database
+            </summary>
+        </member>
+        <member name="M:Universe.Interfaces.IGalaxy`1.GenerateQuery(System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Cluster},System.Nullable{Universe.Builder.Options.ColumnOptions},System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.Sorting.Option},System.Collections.Generic.IReadOnlyList{System.String})">
+            <summary>
+            Generate SQL query without executing it
             </summary>
         </member>
         <member name="T:Universe.Interfaces.IGalaxyBasic`1">
@@ -512,7 +517,7 @@
             Create a new model in the database
             </summary>
         </member>
-        <member name="M:Universe.Interfaces.IGalaxyBasic`1.Create(System.Collections.Generic.IList{`0})">
+        <member name="M:Universe.Interfaces.IGalaxyBasic`1.Create(System.Collections.Generic.IReadOnlyList{`0})">
             <summary>
             Bulk create new models in the database
             </summary>
@@ -522,7 +527,7 @@
             Modify a model in the database
             </summary>
         </member>
-        <member name="M:Universe.Interfaces.IGalaxyBasic`1.Modify(System.Collections.Generic.IList{`0})">
+        <member name="M:Universe.Interfaces.IGalaxyBasic`1.Modify(System.Collections.Generic.IReadOnlyList{`0})">
             <summary>
             Bulk modify models in the database
             </summary>


### PR DESCRIPTION
This pull request introduces a new feature for generating SQL queries without executing them, along with related interface and documentation updates. It also adds a new example demonstrating this functionality and updates method signatures throughout the codebase to use `IReadOnlyList<>` for improved immutability and clarity.

**New Query Generation Feature:**

- Added a new method `GenerateQuery` to the `IGalaxy<T>` interface and implemented it in the `Galaxy<T>` class, allowing users to generate SQL queries for debugging, logging, or manual execution without running them. [[1]](diffhunk://#diff-41a659c32fed268a2c6ebe1ca9c6ca16c77cecf9c632571b47e2cd080390ef4aR38-R42) [[2]](diffhunk://#diff-def4394b1561082f6c0b28af2ab1e126138d7959428fd0691f95edc1f5e70150R94-R99)

- Introduced a new example, `Example12_QueryGeneration`, which demonstrates various use cases for generating queries, including simple queries, queries with aggregations, filtered queries with sorting, and queries with array joins. This example is now called in `Program.cs`. [[1]](diffhunk://#diff-f4b55f8fdbd065af5845e03e7c84cc24d89351abf55e35d4cd4028378ca8cfc4R1-R140) [[2]](diffhunk://#diff-20dc0f8388335b40f5bd04238a852a52038bf76a64379d3754bf54ad769dbb9bR61)

**API and Documentation Consistency:**

- Updated the XML documentation in `UniverseQuery.xml` to reflect the new `GenerateQuery` method and changed all relevant method signatures and documentation to use `IReadOnlyList<>` instead of `IList<>` or `IEnumerable<>` for parameters representing collections. This ensures consistency and encourages immutability in API usage. [[1]](diffhunk://#diff-3d1b47123005be8ba727c3fd93b673613d91eea8000103b836007b39baa0fedcL65-R65) [[2]](diffhunk://#diff-3d1b47123005be8ba727c3fd93b673613d91eea8000103b836007b39baa0fedcL103-R103) [[3]](diffhunk://#diff-3d1b47123005be8ba727c3fd93b673613d91eea8000103b836007b39baa0fedcL348-R348) [[4]](diffhunk://#diff-3d1b47123005be8ba727c3fd93b673613d91eea8000103b836007b39baa0fedcL477-R511) [[5]](diffhunk://#diff-3d1b47123005be8ba727c3fd93b673613d91eea8000103b836007b39baa0fedcL515-R520) [[6]](diffhunk://#diff-3d1b47123005be8ba727c3fd93b673613d91eea8000103b836007b39baa0fedcL525-R530)