### PR TITLE
perf: Partition QueryTuner by QueryType and compile regex

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -7,9 +7,9 @@ jobs:
   restore:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
           include-prerelease: true
@@ -20,9 +20,9 @@ jobs:
     needs: restore
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
           include-prerelease: true
@@ -33,9 +33,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
           include-prerelease: true

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
-          include-prerelease: true
+          dotnet-quality: 'preview'
       - name: Restore
         working-directory: ./code/
         run: dotnet restore
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
-          include-prerelease: true
+          dotnet-quality: 'preview'
       - name: Build
         working-directory: ./code/
         run: dotnet build
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.x'
-          include-prerelease: true
+          dotnet-quality: 'preview'
       - name: Test
         working-directory: ./code/
         run: dotnet test --filter "Category!=Performance" --verbosity normal

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -27,3 +27,16 @@ jobs:
       - name: Build
         working-directory: ./code/
         run: dotnet build
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '10.x'
+          include-prerelease: true
+      - name: Test
+        working-directory: ./code/
+        run: dotnet test --filter "Category!=Performance" --verbosity normal

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -1,5 +1,7 @@
 on: push
 name: dotnet-ci
+permissions:
+  contents: read
 
 jobs:
   restore:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,11 @@ Currently (v3.1.x), optimization is rule-based. Full adaptive learning is planne
 - **Main branch**: `dev` (for PRs)
 - **Production branch**: `prod`
 - **Current branch**: `beta`
+- **Code Review**: After every commit or before pushing, run a local CodeRabbit review:
+  ```bash
+  coderabbit review
+  ```
+  Address any findings before pushing to the remote.
 
 ## CI/CD
 - **GitHub Actions**: `.github/workflows/dotnet-ci.yml` runs restore and build on every push

--- a/code/Universe.Tests/Helpers/TestStatisticsFactory.cs
+++ b/code/Universe.Tests/Helpers/TestStatisticsFactory.cs
@@ -1,0 +1,49 @@
+using Universe.Builder.Strategies;
+
+namespace Universe.Tests.Helpers;
+
+internal static class TestStatisticsFactory
+{
+	public static QueryExecutionStatistics Create(
+		string queryHash = "testhash",
+		QueryType type = QueryType.Simple,
+		double ru = 5.0,
+		TimeSpan? executionTime = null,
+		int resultCount = 10,
+		bool success = true,
+		DateTime? timestamp = null,
+		string strategyUsed = "Direct",
+		IReadOnlyDictionary<string, object> hintsUsed = null)
+	{
+		return new QueryExecutionStatistics
+		{
+			QueryHash = queryHash,
+			Type = type,
+			RU = ru,
+			ExecutionTime = executionTime ?? TimeSpan.FromMilliseconds(50),
+			ResultCount = resultCount,
+			Success = success,
+			Timestamp = timestamp ?? DateTime.UtcNow,
+			StrategyUsed = strategyUsed,
+			HintsUsed = hintsUsed
+		};
+	}
+
+	public static List<QueryExecutionStatistics> CreateBatch(
+		int count,
+		QueryType type = QueryType.Simple,
+		string queryHash = "batchhash",
+		string strategyUsed = "Direct")
+	{
+		return Enumerable.Range(0, count)
+			.Select(i => Create(
+				queryHash: queryHash,
+				type: type,
+				ru: 5.0 + i * 0.1,
+				executionTime: TimeSpan.FromMilliseconds(50 + i),
+				resultCount: 10 + i,
+				timestamp: DateTime.UtcNow.AddMinutes(-i),
+				strategyUsed: strategyUsed))
+			.ToList();
+	}
+}

--- a/code/Universe.Tests/Storage/FileStatisticsStorageTests.cs
+++ b/code/Universe.Tests/Storage/FileStatisticsStorageTests.cs
@@ -1,0 +1,147 @@
+using System.Diagnostics;
+using Universe.Builder.Strategies;
+using Universe.Builder.Strategies.Storage;
+using Universe.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Universe.Tests.Storage;
+
+public sealed class FileStatisticsStorageTests : IDisposable
+{
+	private readonly string _filePath;
+	private readonly FileStatisticsStorage _storage;
+	private readonly ITestOutputHelper _output;
+
+	public FileStatisticsStorageTests(ITestOutputHelper output)
+	{
+		_output = output;
+		_filePath = Path.Combine(AppContext.BaseDirectory, $"test-{Guid.NewGuid()}.json");
+		_storage = new FileStatisticsStorage(_filePath);
+	}
+
+	public void Dispose()
+	{
+		_storage.Dispose();
+		try { if (File.Exists(_filePath)) File.Delete(_filePath); }
+		catch { /* best effort cleanup */ }
+	}
+
+	[Fact]
+	public async Task SaveAndLoad_RoundTrip_AllFieldsPreserved()
+	{
+		var hints = new Dictionary<string, object> { ["MaxItemCount"] = 50 };
+		var stat = TestStatisticsFactory.Create(
+			queryHash: "file-abc",
+			type: QueryType.Aggregation,
+			ru: 33.3,
+			executionTime: TimeSpan.FromMilliseconds(200),
+			resultCount: 42,
+			success: false,
+			timestamp: new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc),
+			strategyUsed: "Gateway",
+			hintsUsed: hints);
+
+		await _storage.SaveAsync(stat);
+		var loaded = await _storage.LoadRecentAsync(10);
+
+		Assert.Single(loaded);
+		var result = loaded[0];
+		Assert.Equal("file-abc", result.QueryHash);
+		Assert.Equal(QueryType.Aggregation, result.Type);
+		Assert.Equal(33.3, result.RU);
+		Assert.Equal(200, result.ExecutionTime.TotalMilliseconds);
+		Assert.Equal(42, result.ResultCount);
+		Assert.False(result.Success);
+		Assert.Equal("Gateway", result.StrategyUsed);
+	}
+
+	[Fact]
+	public async Task LoadRecentAsync_RespectsLimit()
+	{
+		for (int i = 0; i < 10; i++)
+		{
+			await _storage.SaveAsync(TestStatisticsFactory.Create(
+				queryHash: $"limit-{i}",
+				timestamp: DateTime.UtcNow.AddMinutes(-i)));
+		}
+
+		var loaded = await _storage.LoadRecentAsync(5);
+
+		Assert.Equal(5, loaded.Count);
+		// Most recent first
+		Assert.True(loaded[0].Timestamp >= loaded[1].Timestamp);
+	}
+
+	[Fact]
+	public async Task SaveAsync_TruncatesAt1000Entries()
+	{
+		// Save 1005 entries
+		for (int i = 0; i < 1005; i++)
+		{
+			await _storage.SaveAsync(TestStatisticsFactory.Create(
+				queryHash: $"trunc-{i}",
+				timestamp: DateTime.UtcNow.AddSeconds(-i)));
+		}
+
+		var loaded = await _storage.LoadRecentAsync(2000);
+
+		Assert.Equal(1000, loaded.Count);
+		// Should keep the most recent 1000
+		Assert.Equal("trunc-0", loaded[0].QueryHash);
+	}
+
+	[Fact]
+	public async Task CorruptJson_RecoversGracefully()
+	{
+		// Write corrupt JSON directly to the file
+		await File.WriteAllTextAsync(_filePath, "{ this is not valid json [[[");
+
+		// LoadRecentAsync should return empty (not throw)
+		var loaded = await _storage.LoadRecentAsync(10);
+		Assert.Empty(loaded);
+
+		// Should be able to save new data after recovery
+		await _storage.SaveAsync(TestStatisticsFactory.Create(queryHash: "recovered"));
+		var loadedAfter = await _storage.LoadRecentAsync(10);
+		Assert.Single(loadedAfter);
+		Assert.Equal("recovered", loadedAfter[0].QueryHash);
+	}
+
+	[Fact]
+	public void InvalidPath_OutsideAppDirectory_Throws()
+	{
+		Assert.Throws<Universe.Exception.UniverseException>(() =>
+			new FileStatisticsStorage("/tmp/outside-app-dir.json"));
+	}
+
+	[Fact]
+	[Trait("Category", "Performance")]
+	public async Task SaveAsync_PerformanceAtDifferentScales()
+	{
+		int[] scales = [10, 100, 500, 1000];
+
+		foreach (int scale in scales)
+		{
+			string filePath = Path.Combine(AppContext.BaseDirectory, $"perf-file-{scale}-{Guid.NewGuid()}.json");
+			using var storage = new FileStatisticsStorage(filePath);
+
+			var sw = Stopwatch.StartNew();
+			for (int i = 0; i < scale; i++)
+			{
+				await storage.SaveAsync(TestStatisticsFactory.Create(
+					queryHash: $"perf-{i}",
+					timestamp: DateTime.UtcNow.AddSeconds(-i)));
+			}
+			sw.Stop();
+
+			_output.WriteLine($"FileStorage SaveAsync x{scale}: {sw.Elapsed.TotalMilliseconds:F2}ms ({sw.Elapsed.TotalMilliseconds / scale:F2}ms/call)");
+
+			try { File.Delete(filePath); }
+			catch { /* best effort */ }
+		}
+
+		// This test documents O(n) per-call growth (total is O(n^2))
+		// since each SaveAsync loads all existing records, appends, and writes back
+	}
+}

--- a/code/Universe.Tests/Storage/InMemoryStatisticsStorageTests.cs
+++ b/code/Universe.Tests/Storage/InMemoryStatisticsStorageTests.cs
@@ -1,0 +1,44 @@
+using Universe.Builder.Strategies;
+using Universe.Builder.Strategies.Storage;
+using Universe.Tests.Helpers;
+using Xunit;
+
+namespace Universe.Tests.Storage;
+
+public sealed class InMemoryStatisticsStorageTests
+{
+	[Fact]
+	public async Task SaveAsync_ReturnsCompletedTask()
+	{
+		var storage = new InMemoryStatisticsStorage();
+		var task = storage.SaveAsync(TestStatisticsFactory.Create());
+
+		Assert.True(task.IsCompleted);
+		await task; // should not throw
+	}
+
+	[Fact]
+	public async Task LoadRecentAsync_ReturnsEmpty()
+	{
+		var storage = new InMemoryStatisticsStorage();
+		var result = await storage.LoadRecentAsync(100);
+
+		Assert.Empty(result);
+	}
+
+	[Fact]
+	public async Task GetByQueryHashAsync_ReturnsEmpty()
+	{
+		var storage = new InMemoryStatisticsStorage();
+		var result = await storage.GetByQueryHashAsync("anyhash", TimeSpan.FromHours(1));
+
+		Assert.Empty(result);
+	}
+
+	[Fact]
+	public async Task ClearOldAsync_Completes()
+	{
+		var storage = new InMemoryStatisticsStorage();
+		await storage.ClearOldAsync(TimeSpan.FromDays(1)); // should not throw
+	}
+}

--- a/code/Universe.Tests/Storage/SqliteStatisticsStorageTests.cs
+++ b/code/Universe.Tests/Storage/SqliteStatisticsStorageTests.cs
@@ -1,0 +1,324 @@
+using Universe.Builder.Strategies;
+using Universe.Builder.Strategies.Storage;
+using Universe.Tests.Helpers;
+using Xunit;
+
+namespace Universe.Tests.Storage;
+
+public sealed class SqliteStatisticsStorageTests : IDisposable
+{
+	private readonly string _dbPath;
+	private readonly SqliteStatisticsStorage _storage;
+
+	public SqliteStatisticsStorageTests()
+	{
+		_dbPath = Path.Combine(AppContext.BaseDirectory, $"test-{Guid.NewGuid()}.db");
+		_storage = new SqliteStatisticsStorage(_dbPath, batchSize: 1, flushIntervalSeconds: 60);
+	}
+
+	public void Dispose()
+	{
+		_storage.Dispose();
+		TryDeleteFiles(_dbPath);
+	}
+
+	private static void TryDeleteFiles(string dbPath)
+	{
+		foreach (string suffix in new[] { "", "-wal", "-shm" })
+		{
+			try { if (File.Exists(dbPath + suffix)) File.Delete(dbPath + suffix); }
+			catch { /* best effort cleanup */ }
+		}
+	}
+
+	#region Round-trip
+
+	[Fact]
+	public async Task SaveAndLoad_RoundTrip_AllFieldsPreserved()
+	{
+		var hints = new Dictionary<string, object> { ["MaxItemCount"] = 50 };
+		var stat = TestStatisticsFactory.Create(
+			queryHash: "abc123",
+			type: QueryType.VectorSearch,
+			ru: 42.5,
+			executionTime: TimeSpan.FromMilliseconds(150),
+			resultCount: 25,
+			success: true,
+			timestamp: DateTime.UtcNow,
+			strategyUsed: "VectorSearch",
+			hintsUsed: hints);
+
+		await _storage.SaveAsync(stat);
+		IList<QueryExecutionStatistics> loaded = await _storage.LoadRecentAsync(10);
+
+		Assert.Single(loaded);
+		var result = loaded[0];
+		Assert.Equal("abc123", result.QueryHash);
+		Assert.Equal(QueryType.VectorSearch, result.Type);
+		Assert.Equal(42.5, result.RU);
+		Assert.Equal(150, result.ExecutionTime.TotalMilliseconds);
+		Assert.Equal(25, result.ResultCount);
+		Assert.True(result.Success);
+		Assert.Equal("VectorSearch", result.StrategyUsed);
+		Assert.NotNull(result.HintsUsed);
+	}
+
+	[Fact]
+	public async Task SaveAndLoad_NullHintsAndStrategy_Preserved()
+	{
+		var stat = TestStatisticsFactory.Create(strategyUsed: null, hintsUsed: null);
+		await _storage.SaveAsync(stat);
+		var loaded = await _storage.LoadRecentAsync(10);
+
+		Assert.Single(loaded);
+		Assert.Null(loaded[0].StrategyUsed);
+		Assert.Null(loaded[0].HintsUsed);
+	}
+
+	#endregion
+
+	#region Query behavior
+
+	[Fact]
+	public async Task LoadRecentAsync_RespectsCountAndOrdering()
+	{
+		for (int i = 0; i < 5; i++)
+		{
+			await _storage.SaveAsync(TestStatisticsFactory.Create(
+				queryHash: $"hash-{i}",
+				timestamp: DateTime.UtcNow.AddMinutes(-i)));
+		}
+
+		var loaded = await _storage.LoadRecentAsync(3);
+
+		Assert.Equal(3, loaded.Count);
+		// Most recent first
+		Assert.True(loaded[0].Timestamp >= loaded[1].Timestamp);
+		Assert.True(loaded[1].Timestamp >= loaded[2].Timestamp);
+	}
+
+	[Fact]
+	public async Task GetByQueryHashAsync_FiltersByHashAndTimeWindow()
+	{
+		await _storage.SaveAsync(TestStatisticsFactory.Create(queryHash: "target"));
+		await _storage.SaveAsync(TestStatisticsFactory.Create(queryHash: "other"));
+		await _storage.SaveAsync(TestStatisticsFactory.Create(
+			queryHash: "target",
+			timestamp: DateTime.UtcNow.AddDays(-10))); // outside window
+
+		var results = await _storage.GetByQueryHashAsync("target", TimeSpan.FromHours(1));
+
+		Assert.Single(results);
+		Assert.Equal("target", results[0].QueryHash);
+	}
+
+	#endregion
+
+	#region Cleanup
+
+	[Fact]
+	public async Task ClearOldAsync_RemovesExpiredRecords()
+	{
+		await _storage.SaveAsync(TestStatisticsFactory.Create(
+			queryHash: "old", timestamp: DateTime.UtcNow.AddDays(-5)));
+		await _storage.SaveAsync(TestStatisticsFactory.Create(
+			queryHash: "recent", timestamp: DateTime.UtcNow));
+
+		var allBefore = await _storage.LoadRecentAsync(100);
+		Assert.Equal(2, allBefore.Count);
+
+		await _storage.ClearOldAsync(TimeSpan.FromDays(1));
+
+		var allAfter = await _storage.LoadRecentAsync(100);
+		Assert.Single(allAfter);
+		Assert.Equal("recent", allAfter[0].QueryHash);
+	}
+
+	[Fact]
+	public async Task ClearOldAsync_EmptyDatabase_DoesNotThrow()
+	{
+		await _storage.ClearOldAsync(TimeSpan.FromDays(1));
+	}
+
+	#endregion
+
+	#region Batching
+
+	[Fact]
+	public async Task BatchFlushing_DataPersistsCorrectly()
+	{
+		string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-batch-{Guid.NewGuid()}.db");
+		using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 5, flushIntervalSeconds: 300);
+
+		for (int i = 0; i < 5; i++)
+			await storage.SaveAsync(TestStatisticsFactory.Create(queryHash: $"batch-{i}"));
+
+		// Allow fire-and-forget flush triggered at batchSize threshold
+		await Task.Delay(500);
+
+		var loaded = await storage.LoadRecentAsync(100);
+		Assert.Equal(5, loaded.Count);
+
+		storage.Dispose();
+		TryDeleteFiles(dbPath);
+	}
+
+	[Fact]
+	public async Task TimerFlush_PersistsDataBelowBatchThreshold()
+	{
+		string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-timer-{Guid.NewGuid()}.db");
+		using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 100, flushIntervalSeconds: 1);
+
+		// Save below batch threshold
+		for (int i = 0; i < 3; i++)
+			await storage.SaveAsync(TestStatisticsFactory.Create(queryHash: $"timer-{i}"));
+
+		// Wait for timer-based flush (1 second interval)
+		await Task.Delay(2000);
+
+		var loaded = await storage.LoadRecentAsync(100);
+		Assert.Equal(3, loaded.Count);
+
+		storage.Dispose();
+		TryDeleteFiles(dbPath);
+	}
+
+	#endregion
+
+	#region Dispose
+
+	[Fact]
+	public async Task Dispose_FlushesRemainingQueue()
+	{
+		string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-dispose-{Guid.NewGuid()}.db");
+		// Large batch + long interval so items stay queued until Dispose
+		var storage = new SqliteStatisticsStorage(dbPath, batchSize: 100, flushIntervalSeconds: 300);
+
+		for (int i = 0; i < 5; i++)
+			await storage.SaveAsync(TestStatisticsFactory.Create(queryHash: $"dispose-{i}"));
+
+		storage.Dispose();
+
+		// Re-open and verify data was flushed during Dispose
+		using var storage2 = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
+		var loaded = await storage2.LoadRecentAsync(100);
+		Assert.Equal(5, loaded.Count);
+
+		storage2.Dispose();
+		TryDeleteFiles(dbPath);
+	}
+
+	[Fact]
+	public void DoubleDispose_DoesNotThrow()
+	{
+		string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-dd-{Guid.NewGuid()}.db");
+		var storage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
+		storage.Dispose();
+		storage.Dispose(); // should not throw
+		TryDeleteFiles(dbPath);
+	}
+
+	[Fact]
+	public async Task SaveAsync_AfterDispose_IsNoOp()
+	{
+		string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-noop-{Guid.NewGuid()}.db");
+		var storage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
+		storage.Dispose();
+
+		await storage.SaveAsync(TestStatisticsFactory.Create()); // should not throw
+		TryDeleteFiles(dbPath);
+	}
+
+	#endregion
+
+	#region Validation
+
+	[Fact]
+	public void InvalidPath_OutsideAppDirectory_Throws()
+	{
+		Assert.Throws<Universe.Exception.UniverseException>(() =>
+			new SqliteStatisticsStorage("/tmp/outside-app-dir.db"));
+	}
+
+	[Fact]
+	public void InvalidRetentionDays_Throws()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(() =>
+			new SqliteStatisticsStorage(retentionDays: 0));
+	}
+
+	[Fact]
+	public void InvalidBatchSize_Throws()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(() =>
+			new SqliteStatisticsStorage(batchSize: 0));
+	}
+
+	[Fact]
+	public void InvalidFlushInterval_Throws()
+	{
+		Assert.Throws<ArgumentOutOfRangeException>(() =>
+			new SqliteStatisticsStorage(flushIntervalSeconds: 0));
+	}
+
+	#endregion
+
+	#region Concurrency
+
+	[Fact]
+	public async Task ConcurrentSaves_AllRecordsPersisted()
+	{
+		string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-conc-{Guid.NewGuid()}.db");
+		using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 5, flushIntervalSeconds: 1);
+
+		var tasks = Enumerable.Range(0, 10).Select(taskId =>
+			Task.Run(async () =>
+			{
+				for (int i = 0; i < 10; i++)
+				{
+					await storage.SaveAsync(TestStatisticsFactory.Create(
+						queryHash: $"t{taskId}-i{i}"));
+				}
+			}));
+
+		await Task.WhenAll(tasks);
+
+		var loaded = await storage.LoadRecentAsync(200);
+		Assert.Equal(100, loaded.Count);
+
+		storage.Dispose();
+		TryDeleteFiles(dbPath);
+	}
+
+	[Fact]
+	public async Task ConcurrentSaveAndLoad_CompletesWithoutDeadlock()
+	{
+		string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-dl-{Guid.NewGuid()}.db");
+		using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 2, flushIntervalSeconds: 1);
+
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+		var saveTask = Task.Run(async () =>
+		{
+			for (int i = 0; i < 50 && !cts.IsCancellationRequested; i++)
+				await storage.SaveAsync(TestStatisticsFactory.Create(queryHash: $"dl-{i}"));
+		});
+
+		var loadTask = Task.Run(async () =>
+		{
+			for (int i = 0; i < 10 && !cts.IsCancellationRequested; i++)
+			{
+				await storage.LoadRecentAsync(10);
+				await Task.Delay(50);
+			}
+		});
+
+		// If we reach here without timeout, no deadlock occurred
+		await Task.WhenAll(saveTask, loadTask);
+
+		storage.Dispose();
+		TryDeleteFiles(dbPath);
+	}
+
+	#endregion
+}

--- a/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
@@ -41,8 +41,10 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
 		_output.WriteLine($"Ratio: {loadedTime.TotalMilliseconds / Math.Max(emptyTime.TotalMilliseconds, 0.001):F2}x");
 
 		// Loaded should be measurably slower due to LINQ iteration over the full queue
-		Assert.True(loadedTime > emptyTime,
-			$"Expected loaded ({loadedTime.TotalMilliseconds:F2}ms) > empty ({emptyTime.TotalMilliseconds:F2}ms)");
+		// Use ratio threshold to tolerate CI variability
+		double ratio = loadedTime.TotalMilliseconds / Math.Max(emptyTime.TotalMilliseconds, 0.001);
+		Assert.True(ratio > 1.1 || loadedTime.TotalMilliseconds > emptyTime.TotalMilliseconds + 0.5,
+			$"Expected loaded ({loadedTime.TotalMilliseconds:F2}ms) to be meaningfully slower than empty ({emptyTime.TotalMilliseconds:F2}ms), ratio: {ratio:F2}x");
 	}
 
 	[Fact]
@@ -74,9 +76,10 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
 			_output.WriteLine($"Queue size {targetSize,4}: {sw.Elapsed.TotalMilliseconds:F2}ms for 100 calls");
 		}
 
-		// Verify general upward trend
-		Assert.True(timings[1000] > timings[0],
-			$"Expected 1000-item timing ({timings[1000]:F2}ms) > 0-item timing ({timings[0]:F2}ms)");
+		// Verify general upward trend with tolerance for CI variability
+		double scalingRatio = timings[1000] / Math.Max(timings[0], 0.001);
+		Assert.True(scalingRatio > 1.1 || timings[1000] > timings[0] + 0.5,
+			$"Expected 1000-item timing ({timings[1000]:F2}ms) to be meaningfully slower than 0-item timing ({timings[0]:F2}ms), ratio: {scalingRatio:F2}x");
 	}
 
 	[Fact]
@@ -134,8 +137,10 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
 		_output.WriteLine($"Ratio: {simpleTime.TotalMilliseconds / Math.Max(aggTime.TotalMilliseconds, 0.001):F2}x");
 
 		// Aggregation with 50 items should be faster than Simple with 950 items
-		Assert.True(aggTime < simpleTime,
-			$"Expected Aggregation ({aggTime.TotalMilliseconds:F2}ms) < Simple ({simpleTime.TotalMilliseconds:F2}ms)");
+		// Use ratio threshold to tolerate CI variability
+		double typeRatio = simpleTime.TotalMilliseconds / Math.Max(aggTime.TotalMilliseconds, 0.001);
+		Assert.True(typeRatio > 1.1 || simpleTime.TotalMilliseconds > aggTime.TotalMilliseconds + 0.5,
+			$"Expected Simple ({simpleTime.TotalMilliseconds:F2}ms) to be meaningfully slower than Aggregation ({aggTime.TotalMilliseconds:F2}ms), ratio: {typeRatio:F2}x");
 	}
 
 	[Fact]

--- a/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
@@ -1,0 +1,203 @@
+using System.Diagnostics;
+using Universe.Builder.Strategies;
+using Universe.Builder.Strategies.Storage;
+using Universe.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Universe.Tests.Tuner;
+
+public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
+{
+	private readonly ITestOutputHelper _output = output;
+
+	[Fact]
+	[Trait("Category", "Performance")]
+	public void GetRecommendations_EmptyQueueVsLoadedQueue_ShowsOverhead()
+	{
+		// Baseline: empty queue
+		using var emptyTuner = new QueryTuner();
+		var sw = Stopwatch.StartNew();
+		for (int i = 0; i < 1000; i++)
+			emptyTuner.GetRecommendations(QueryType.Simple);
+		sw.Stop();
+		var emptyTime = sw.Elapsed;
+
+		// Loaded: 1000-item queue
+		using var loadedTuner = new QueryTuner();
+		for (int i = 0; i < 1000; i++)
+			loadedTuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Simple,
+				timestamp: DateTime.UtcNow));
+
+		sw.Restart();
+		for (int i = 0; i < 1000; i++)
+			loadedTuner.GetRecommendations(QueryType.Simple);
+		sw.Stop();
+		var loadedTime = sw.Elapsed;
+
+		_output.WriteLine($"Empty queue: {emptyTime.TotalMilliseconds:F2}ms for 1000 calls");
+		_output.WriteLine($"Loaded queue (1000 items): {loadedTime.TotalMilliseconds:F2}ms for 1000 calls");
+		_output.WriteLine($"Ratio: {loadedTime.TotalMilliseconds / Math.Max(emptyTime.TotalMilliseconds, 0.001):F2}x");
+
+		// Loaded should be measurably slower due to LINQ iteration over the full queue
+		Assert.True(loadedTime > emptyTime,
+			$"Expected loaded ({loadedTime.TotalMilliseconds:F2}ms) > empty ({emptyTime.TotalMilliseconds:F2}ms)");
+	}
+
+	[Fact]
+	[Trait("Category", "Performance")]
+	public void GetRecommendations_LinearScaling_TimingsIncreaseWithQueueSize()
+	{
+		int[] sizes = [0, 100, 250, 500, 750, 1000];
+		var timings = new Dictionary<int, double>();
+
+		using var tuner = new QueryTuner();
+		int currentSize = 0;
+
+		foreach (int targetSize in sizes)
+		{
+			while (currentSize < targetSize)
+			{
+				tuner.RecordExecution(TestStatisticsFactory.Create(
+					type: QueryType.Simple,
+					timestamp: DateTime.UtcNow));
+				currentSize++;
+			}
+
+			var sw = Stopwatch.StartNew();
+			for (int i = 0; i < 100; i++)
+				tuner.GetRecommendations(QueryType.Simple);
+			sw.Stop();
+
+			timings[targetSize] = sw.Elapsed.TotalMilliseconds;
+			_output.WriteLine($"Queue size {targetSize,4}: {sw.Elapsed.TotalMilliseconds:F2}ms for 100 calls");
+		}
+
+		// Verify general upward trend
+		Assert.True(timings[1000] > timings[0],
+			$"Expected 1000-item timing ({timings[1000]:F2}ms) > 0-item timing ({timings[0]:F2}ms)");
+	}
+
+	[Fact]
+	[Trait("Category", "Performance")]
+	public void GetRecommendations_CumulativeOverhead_WithFullQueue()
+	{
+		using var tuner = new QueryTuner();
+		for (int i = 0; i < 1000; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Simple,
+				timestamp: DateTime.UtcNow));
+
+		var sw = Stopwatch.StartNew();
+		for (int i = 0; i < 1000; i++)
+			tuner.GetRecommendations(QueryType.Simple);
+		sw.Stop();
+
+		_output.WriteLine($"1000 GetRecommendations calls with 1000-item queue: {sw.Elapsed.TotalMilliseconds:F2}ms total");
+		_output.WriteLine($"Per call: {sw.Elapsed.TotalMilliseconds / 1000:F4}ms");
+		_output.WriteLine("This overhead is added to EVERY Cosmos DB query when SQLite storage is configured.");
+	}
+
+	[Fact]
+	[Trait("Category", "Performance")]
+	public void ComputeQueryHash_10000Calls_Performance()
+	{
+		var context = new QueryContext(QueryType.Simple);
+		string queryText = "SELECT * FROM c WHERE c.id = @p1 AND c.name = @p2 AND c.status = @p3";
+
+		var sw = Stopwatch.StartNew();
+		for (int i = 0; i < 10000; i++)
+			QueryTuner.ComputeQueryHash(context, queryText);
+		sw.Stop();
+
+		_output.WriteLine($"10000 ComputeQueryHash calls: {sw.Elapsed.TotalMilliseconds:F2}ms");
+		_output.WriteLine($"Per call: {sw.Elapsed.TotalMilliseconds / 10000:F4}ms");
+	}
+
+	[Fact]
+	[Trait("Category", "Performance")]
+	public void RecordExecution_WithSqlite_StaysResponsive()
+	{
+		string dbPath = Path.Combine(AppContext.BaseDirectory, $"perf-record-{Guid.NewGuid()}.db");
+		using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 10, flushIntervalSeconds: 60);
+		using var tuner = new QueryTuner(storage);
+
+		var sw = Stopwatch.StartNew();
+		for (int i = 0; i < 100; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(queryHash: $"perf-{i}"));
+		sw.Stop();
+
+		_output.WriteLine($"100 RecordExecution calls with SQLite: {sw.Elapsed.TotalMilliseconds:F2}ms");
+		_output.WriteLine($"Per call: {sw.Elapsed.TotalMilliseconds / 100:F4}ms");
+
+		// Fire-and-forget persistence should keep RecordExecution fast
+		Assert.True(sw.Elapsed.TotalMilliseconds < 1000,
+			$"100 RecordExecution calls took {sw.Elapsed.TotalMilliseconds:F2}ms, expected < 1000ms");
+
+		TryDeleteFiles(dbPath);
+	}
+
+	[Fact]
+	[Trait("Category", "Performance")]
+	public async Task StartupLoad_SqliteVsInMemory_MeasuresImpact()
+	{
+		string dbPath = Path.Combine(AppContext.BaseDirectory, $"perf-startup-{Guid.NewGuid()}.db");
+
+		// Pre-seed SQLite with 1000 records
+		using (var seedStorage = new SqliteStatisticsStorage(dbPath, batchSize: 50, flushIntervalSeconds: 60))
+		{
+			for (int i = 0; i < 1000; i++)
+				await seedStorage.SaveAsync(TestStatisticsFactory.Create(
+					type: QueryType.Simple,
+					queryHash: $"startup-{i}",
+					timestamp: DateTime.UtcNow.AddMinutes(-i)));
+
+			// Ensure flushed
+			await seedStorage.LoadRecentAsync(1);
+		}
+
+		// Measure InMemory startup
+		var sw = Stopwatch.StartNew();
+		using var inMemoryTuner = new QueryTuner();
+		await Task.Delay(100); // Give async loading a chance
+		var inMemoryRec = inMemoryTuner.GetRecommendations(QueryType.Simple);
+		sw.Stop();
+		var inMemoryTime = sw.Elapsed;
+
+		// Measure SQLite startup (loading 1000 records into queue)
+		sw.Restart();
+		using var sqliteStorage = new SqliteStatisticsStorage(dbPath, batchSize: 50, flushIntervalSeconds: 60);
+		using var sqliteTuner = new QueryTuner(sqliteStorage);
+
+		// Wait for async loading to complete
+		QueryTuningRecommendations sqliteRec = default;
+		for (int attempt = 0; attempt < 50; attempt++)
+		{
+			sqliteRec = sqliteTuner.GetRecommendations(QueryType.Simple);
+			if (sqliteRec.IsDataDriven) break;
+			await Task.Delay(100);
+		}
+		sw.Stop();
+		var sqliteTime = sw.Elapsed;
+
+		_output.WriteLine($"InMemory startup: {inMemoryTime.TotalMilliseconds:F2}ms (IsDataDriven: {inMemoryRec.IsDataDriven})");
+		_output.WriteLine($"SQLite startup (1000 records): {sqliteTime.TotalMilliseconds:F2}ms (IsDataDriven: {sqliteRec.IsDataDriven})");
+
+		Assert.True(sqliteRec.IsDataDriven,
+			"SQLite should provide data-driven recommendations after loading persisted data");
+		Assert.False(inMemoryRec.IsDataDriven,
+			"InMemory should fall back to rule-based (no persisted data)");
+
+		TryDeleteFiles(dbPath);
+	}
+
+	private static void TryDeleteFiles(string dbPath)
+	{
+		foreach (string suffix in new[] { "", "-wal", "-shm" })
+		{
+			try { if (File.Exists(dbPath + suffix)) File.Delete(dbPath + suffix); }
+			catch { /* best effort cleanup */ }
+		}
+	}
+}

--- a/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
@@ -159,20 +159,22 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
 	public void RecordExecution_WithSqlite_StaysResponsive()
 	{
 		string dbPath = Path.Combine(AppContext.BaseDirectory, $"perf-record-{Guid.NewGuid()}.db");
-		using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 10, flushIntervalSeconds: 60);
-		using var tuner = new QueryTuner(storage);
 
-		var sw = Stopwatch.StartNew();
-		for (int i = 0; i < 100; i++)
-			tuner.RecordExecution(TestStatisticsFactory.Create(queryHash: $"perf-{i}"));
-		sw.Stop();
+		using (var storage = new SqliteStatisticsStorage(dbPath, batchSize: 10, flushIntervalSeconds: 60))
+		using (var tuner = new QueryTuner(storage))
+		{
+			var sw = Stopwatch.StartNew();
+			for (int i = 0; i < 100; i++)
+				tuner.RecordExecution(TestStatisticsFactory.Create(queryHash: $"perf-{i}"));
+			sw.Stop();
 
-		_output.WriteLine($"100 RecordExecution calls with SQLite: {sw.Elapsed.TotalMilliseconds:F2}ms");
-		_output.WriteLine($"Per call: {sw.Elapsed.TotalMilliseconds / 100:F4}ms");
+			_output.WriteLine($"100 RecordExecution calls with SQLite: {sw.Elapsed.TotalMilliseconds:F2}ms");
+			_output.WriteLine($"Per call: {sw.Elapsed.TotalMilliseconds / 100:F4}ms");
 
-		// Fire-and-forget persistence should keep RecordExecution fast
-		Assert.True(sw.Elapsed.TotalMilliseconds < 1000,
-			$"100 RecordExecution calls took {sw.Elapsed.TotalMilliseconds:F2}ms, expected < 1000ms");
+			// Fire-and-forget persistence should keep RecordExecution fast
+			Assert.True(sw.Elapsed.TotalMilliseconds < 1000,
+				$"100 RecordExecution calls took {sw.Elapsed.TotalMilliseconds:F2}ms, expected < 1000ms");
+		}
 
 		TryDeleteFiles(dbPath);
 	}
@@ -205,20 +207,24 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
 		var inMemoryTime = sw.Elapsed;
 
 		// Measure SQLite startup (loading 1000 records into queue)
-		sw.Restart();
-		using var sqliteStorage = new SqliteStatisticsStorage(dbPath, batchSize: 50, flushIntervalSeconds: 60);
-		using var sqliteTuner = new QueryTuner(sqliteStorage);
-
-		// Wait for async loading to complete
-		QueryTuningRecommendations sqliteRec = default;
-		for (int attempt = 0; attempt < 50; attempt++)
+		QueryTuningRecommendations sqliteRec;
+		TimeSpan sqliteTime;
+		using (var sqliteStorage = new SqliteStatisticsStorage(dbPath, batchSize: 50, flushIntervalSeconds: 60))
+		using (var sqliteTuner = new QueryTuner(sqliteStorage))
 		{
-			sqliteRec = sqliteTuner.GetRecommendations(QueryType.Simple);
-			if (sqliteRec.IsDataDriven) break;
-			await Task.Delay(100);
+			sw.Restart();
+
+			// Wait for async loading to complete
+			sqliteRec = default;
+			for (int attempt = 0; attempt < 50; attempt++)
+			{
+				sqliteRec = sqliteTuner.GetRecommendations(QueryType.Simple);
+				if (sqliteRec.IsDataDriven) break;
+				await Task.Delay(100);
+			}
+			sw.Stop();
+			sqliteTime = sw.Elapsed;
 		}
-		sw.Stop();
-		var sqliteTime = sw.Elapsed;
 
 		_output.WriteLine($"InMemory startup: {inMemoryTime.TotalMilliseconds:F2}ms (IsDataDriven: {inMemoryRec.IsDataDriven})");
 		_output.WriteLine($"SQLite startup (1000 records): {sqliteTime.TotalMilliseconds:F2}ms (IsDataDriven: {sqliteRec.IsDataDriven})");

--- a/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
@@ -101,6 +101,45 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
 
 	[Fact]
 	[Trait("Category", "Performance")]
+	public void GetRecommendations_MixedTypes_UnrelatedTypeIsNotAffected()
+	{
+		using var tuner = new QueryTuner();
+
+		// Load 950 Simple entries and 50 Aggregation entries
+		for (int i = 0; i < 950; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Simple, queryHash: $"simple-{i}",
+				timestamp: DateTime.UtcNow));
+		for (int i = 0; i < 50; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Aggregation, queryHash: $"agg-{i}",
+				timestamp: DateTime.UtcNow));
+
+		// Measure 1000 calls for Simple (950-item partition)
+		var sw = Stopwatch.StartNew();
+		for (int i = 0; i < 1000; i++)
+			tuner.GetRecommendations(QueryType.Simple);
+		sw.Stop();
+		var simpleTime = sw.Elapsed;
+
+		// Measure 1000 calls for Aggregation (50-item partition)
+		sw.Restart();
+		for (int i = 0; i < 1000; i++)
+			tuner.GetRecommendations(QueryType.Aggregation);
+		sw.Stop();
+		var aggTime = sw.Elapsed;
+
+		_output.WriteLine($"Simple (950 items): {simpleTime.TotalMilliseconds:F2}ms for 1000 calls");
+		_output.WriteLine($"Aggregation (50 items): {aggTime.TotalMilliseconds:F2}ms for 1000 calls");
+		_output.WriteLine($"Ratio: {simpleTime.TotalMilliseconds / Math.Max(aggTime.TotalMilliseconds, 0.001):F2}x");
+
+		// Aggregation with 50 items should be faster than Simple with 950 items
+		Assert.True(aggTime < simpleTime,
+			$"Expected Aggregation ({aggTime.TotalMilliseconds:F2}ms) < Simple ({simpleTime.TotalMilliseconds:F2}ms)");
+	}
+
+	[Fact]
+	[Trait("Category", "Performance")]
 	public void ComputeQueryHash_10000Calls_Performance()
 	{
 		var context = new QueryContext(QueryType.Simple);

--- a/code/Universe.Tests/Tuner/QueryTunerTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerTests.cs
@@ -1,0 +1,340 @@
+using Universe.Builder.Strategies;
+using Universe.Builder.Strategies.Storage;
+using Universe.Tests.Helpers;
+using Xunit;
+
+namespace Universe.Tests.Tuner;
+
+public sealed class QueryTunerTests
+{
+	#region Queue management
+
+	[Fact]
+	public void RecordExecution_CapsAt1000Entries()
+	{
+		using var tuner = new QueryTuner();
+
+		// Record 200 Aggregation entries first
+		for (int i = 0; i < 200; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Aggregation, queryHash: $"agg-{i}"));
+
+		// Record 1000 Simple entries — should evict all Aggregation entries
+		for (int i = 0; i < 1000; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Simple, queryHash: $"simple-{i}"));
+
+		// Aggregation entries should be fully evicted
+		var aggRec = tuner.GetRecommendations(QueryType.Aggregation);
+		Assert.False(aggRec.IsDataDriven,
+			"Aggregation records should have been evicted by queue cap");
+
+		// Simple entries have enough data for data-driven
+		var simpleRec = tuner.GetRecommendations(QueryType.Simple);
+		Assert.True(simpleRec.IsDataDriven,
+			"Simple records should provide data-driven recommendations");
+	}
+
+	#endregion
+
+	#region Recommendations: rule-based vs data-driven
+
+	[Fact]
+	public void GetRecommendations_LessThan10Samples_ReturnsRuleBased()
+	{
+		using var tuner = new QueryTuner();
+		for (int i = 0; i < 9; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(type: QueryType.Simple));
+
+		var rec = tuner.GetRecommendations(QueryType.Simple);
+
+		Assert.False(rec.IsDataDriven);
+		Assert.Equal(0, rec.SampleSize);
+	}
+
+	[Fact]
+	public void GetRecommendations_AtLeast10Samples_ReturnsDataDriven()
+	{
+		using var tuner = new QueryTuner();
+		for (int i = 0; i < 15; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Simple,
+				ru: 10.0 + i,
+				executionTime: TimeSpan.FromMilliseconds(100 + i * 10),
+				success: i < 12));
+
+		var rec = tuner.GetRecommendations(QueryType.Simple);
+
+		Assert.True(rec.IsDataDriven);
+		Assert.Equal(15, rec.SampleSize);
+		Assert.NotNull(rec.AverageRU);
+		Assert.NotNull(rec.SuccessRate);
+		Assert.NotNull(rec.AverageExecutionTime);
+	}
+
+	#endregion
+
+	#region Time filtering
+
+	[Fact]
+	public void GetRecommendations_OnlyConsidersLast24Hours()
+	{
+		using var tuner = new QueryTuner();
+
+		// Add 15 records older than 24 hours
+		for (int i = 0; i < 15; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Simple,
+				timestamp: DateTime.UtcNow.AddHours(-25)));
+
+		var rec = tuner.GetRecommendations(QueryType.Simple);
+		Assert.False(rec.IsDataDriven);
+	}
+
+	#endregion
+
+	#region Correctness of calculations
+
+	[Fact]
+	public void GetRecommendations_CorrectAverageRU()
+	{
+		using var tuner = new QueryTuner();
+		double[] rus = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0];
+		for (int i = 0; i < rus.Length; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Simple, ru: rus[i]));
+
+		var rec = tuner.GetRecommendations(QueryType.Simple);
+
+		Assert.True(rec.IsDataDriven);
+		Assert.Equal(55.0, rec.AverageRU);
+	}
+
+	[Fact]
+	public void GetRecommendations_CorrectSuccessRate()
+	{
+		using var tuner = new QueryTuner();
+		for (int i = 0; i < 10; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Simple, success: i < 7));
+
+		var rec = tuner.GetRecommendations(QueryType.Simple);
+
+		Assert.True(rec.IsDataDriven);
+		Assert.Equal(0.7, rec.SuccessRate);
+	}
+
+	[Fact]
+	public void GetRecommendations_CorrectAverageExecutionTime()
+	{
+		using var tuner = new QueryTuner();
+		for (int i = 0; i < 10; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Simple,
+				executionTime: TimeSpan.FromMilliseconds(100 * (i + 1))));
+
+		var rec = tuner.GetRecommendations(QueryType.Simple);
+
+		Assert.True(rec.IsDataDriven);
+		// Average of 100, 200, ..., 1000 = 550ms
+		Assert.Equal(550.0, rec.AverageExecutionTime!.Value.TotalMilliseconds);
+	}
+
+	#endregion
+
+	#region Rule-based hints per QueryType
+
+	[Fact]
+	public void GetRuleBasedRecommendations_VectorSearch_HasCorrectHints()
+	{
+		using var tuner = new QueryTuner();
+		var rec = tuner.GetRecommendations(QueryType.VectorSearch);
+
+		Assert.False(rec.IsDataDriven);
+		Assert.NotNull(rec.SuggestedHints);
+		Assert.True(rec.SuggestedHints.ContainsKey("MaxItemCount"));
+		Assert.True(rec.SuggestedHints.ContainsKey("MaxBufferedItemCount"));
+	}
+
+	[Fact]
+	public void GetRuleBasedRecommendations_FullTextSearch_HasCorrectHints()
+	{
+		using var tuner = new QueryTuner();
+		var rec = tuner.GetRecommendations(QueryType.FullTextSearch);
+
+		Assert.False(rec.IsDataDriven);
+		Assert.NotNull(rec.SuggestedHints);
+		Assert.True(rec.SuggestedHints.ContainsKey("MaxItemCount"));
+	}
+
+	[Fact]
+	public void GetRuleBasedRecommendations_Aggregation_HasCorrectHints()
+	{
+		using var tuner = new QueryTuner();
+		var rec = tuner.GetRecommendations(QueryType.Aggregation);
+
+		Assert.False(rec.IsDataDriven);
+		Assert.NotNull(rec.SuggestedHints);
+		Assert.Equal(500, rec.SuggestedHints["MaxItemCount"]);
+		Assert.Equal(1000, rec.SuggestedHints["MaxBufferedItemCount"]);
+	}
+
+	[Fact]
+	public void GetRuleBasedRecommendations_Complex_HasCorrectHints()
+	{
+		using var tuner = new QueryTuner();
+		var rec = tuner.GetRecommendations(QueryType.Complex);
+
+		Assert.False(rec.IsDataDriven);
+		Assert.NotNull(rec.SuggestedHints);
+		Assert.Equal(1, rec.SuggestedHints["MaxConcurrency"]);
+		Assert.Equal(1, rec.SuggestedHints["ResponseContinuationTokenLimitInKb"]);
+	}
+
+	[Fact]
+	public void GetRuleBasedRecommendations_Simple_EmptyHints()
+	{
+		using var tuner = new QueryTuner();
+		var rec = tuner.GetRecommendations(QueryType.Simple);
+
+		Assert.False(rec.IsDataDriven);
+		Assert.NotNull(rec.SuggestedHints);
+		Assert.Empty(rec.SuggestedHints);
+	}
+
+	#endregion
+
+	#region ComputeQueryHash
+
+	[Fact]
+	public void ComputeQueryHash_Deterministic()
+	{
+		var context = new QueryContext(QueryType.Simple);
+		string query = "SELECT * FROM c WHERE c.id = @p1";
+
+		string hash1 = QueryTuner.ComputeQueryHash(context, query);
+		string hash2 = QueryTuner.ComputeQueryHash(context, query);
+
+		Assert.Equal(hash1, hash2);
+	}
+
+	[Fact]
+	public void ComputeQueryHash_NormalizesParameterNames()
+	{
+		var context = new QueryContext(QueryType.Simple);
+		string query1 = "SELECT * FROM c WHERE c.id = @param_abc123";
+		string query2 = "SELECT * FROM c WHERE c.id = @param_xyz789";
+
+		string hash1 = QueryTuner.ComputeQueryHash(context, query1);
+		string hash2 = QueryTuner.ComputeQueryHash(context, query2);
+
+		Assert.Equal(hash1, hash2);
+	}
+
+	[Fact]
+	public void ComputeQueryHash_DifferentQueries_DifferentHashes()
+	{
+		var context = new QueryContext(QueryType.Simple);
+		string query1 = "SELECT * FROM c WHERE c.id = @p1";
+		string query2 = "SELECT * FROM c WHERE c.name = @p1";
+
+		string hash1 = QueryTuner.ComputeQueryHash(context, query1);
+		string hash2 = QueryTuner.ComputeQueryHash(context, query2);
+
+		Assert.NotEqual(hash1, hash2);
+	}
+
+	[Fact]
+	public void ComputeQueryHash_DifferentQueryTypes_DifferentHashes()
+	{
+		var context1 = new QueryContext(QueryType.Simple);
+		var context2 = new QueryContext(QueryType.Aggregation);
+		string query = "SELECT * FROM c WHERE c.id = @p1";
+
+		string hash1 = QueryTuner.ComputeQueryHash(context1, query);
+		string hash2 = QueryTuner.ComputeQueryHash(context2, query);
+
+		Assert.NotEqual(hash1, hash2);
+	}
+
+	#endregion
+
+	#region Startup loading
+
+	[Fact]
+	public async Task Constructor_LoadsPersistedStatisticsFromSqlite()
+	{
+		string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-startup-{Guid.NewGuid()}.db");
+
+		// Pre-seed SQLite with 15 Simple records
+		using (var seedStorage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60))
+		{
+			for (int i = 0; i < 15; i++)
+				await seedStorage.SaveAsync(TestStatisticsFactory.Create(
+					type: QueryType.Simple,
+					queryHash: $"startup-{i}",
+					timestamp: DateTime.UtcNow.AddMinutes(-i)));
+
+			// Ensure flushed
+			await seedStorage.LoadRecentAsync(1);
+		}
+
+		// Create new QueryTuner with fresh SQLite storage
+		using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
+		using var tuner = new QueryTuner(storage);
+
+		// Wait for async loading (poll until data-driven or timeout)
+		QueryTuningRecommendations rec = default;
+		for (int attempt = 0; attempt < 50; attempt++)
+		{
+			rec = tuner.GetRecommendations(QueryType.Simple);
+			if (rec.IsDataDriven) break;
+			await Task.Delay(100);
+		}
+
+		Assert.True(rec.IsDataDriven,
+			"QueryTuner should load persisted statistics on startup");
+		Assert.Equal(15, rec.SampleSize);
+
+		TryDeleteFiles(dbPath);
+	}
+
+	#endregion
+
+	#region Dispose
+
+	[Fact]
+	public void Dispose_DisposesUnderlyingStorage()
+	{
+		var trackable = new TrackingDisposableStorage();
+		var tuner = new QueryTuner(trackable);
+
+		tuner.Dispose();
+
+		Assert.True(trackable.IsDisposed);
+	}
+
+	private sealed class TrackingDisposableStorage : IQueryStatisticsStorage, IDisposable
+	{
+		public bool IsDisposed { get; private set; }
+
+		public Task SaveAsync(QueryExecutionStatistics stats) => Task.CompletedTask;
+		public Task<IList<QueryExecutionStatistics>> LoadRecentAsync(int count)
+			=> Task.FromResult<IList<QueryExecutionStatistics>>([]);
+		public Task<IList<QueryExecutionStatistics>> GetByQueryHashAsync(string queryHash, TimeSpan window)
+			=> Task.FromResult<IList<QueryExecutionStatistics>>([]);
+		public Task ClearOldAsync(TimeSpan olderThan) => Task.CompletedTask;
+		public void Dispose() => IsDisposed = true;
+	}
+
+	#endregion
+
+	private static void TryDeleteFiles(string dbPath)
+	{
+		foreach (string suffix in new[] { "", "-wal", "-shm" })
+		{
+			try { if (File.Exists(dbPath + suffix)) File.Delete(dbPath + suffix); }
+			catch { /* best effort cleanup */ }
+		}
+	}
+}

--- a/code/Universe.Tests/Tuner/QueryTunerTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerTests.cs
@@ -35,6 +35,77 @@ public sealed class QueryTunerTests
 			"Simple records should provide data-driven recommendations");
 	}
 
+	[Fact]
+	public void GetRecommendations_OnlyConsidersEntriesOfRequestedType()
+	{
+		using var tuner = new QueryTuner();
+
+		// Record 200 Simple, 200 Aggregation, 100 VectorSearch
+		for (int i = 0; i < 200; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Simple, queryHash: $"simple-{i}"));
+		for (int i = 0; i < 200; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Aggregation, queryHash: $"agg-{i}"));
+		for (int i = 0; i < 100; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.VectorSearch, queryHash: $"vec-{i}"));
+
+		var simpleRec = tuner.GetRecommendations(QueryType.Simple);
+		var aggRec = tuner.GetRecommendations(QueryType.Aggregation);
+		var vecRec = tuner.GetRecommendations(QueryType.VectorSearch);
+		var joinRec = tuner.GetRecommendations(QueryType.Join);
+
+		Assert.True(simpleRec.IsDataDriven);
+		Assert.Equal(200, simpleRec.SampleSize);
+
+		Assert.True(aggRec.IsDataDriven);
+		Assert.Equal(200, aggRec.SampleSize);
+
+		Assert.True(vecRec.IsDataDriven);
+		Assert.Equal(100, vecRec.SampleSize);
+
+		// Join has no entries — should be rule-based
+		Assert.False(joinRec.IsDataDriven);
+	}
+
+	[Fact]
+	public void RecordExecution_GlobalCapAppliesAcrossAllTypes()
+	{
+		using var tuner = new QueryTuner();
+
+		// Record 500 Simple (oldest), then 500 Aggregation, then 100 VectorSearch
+		for (int i = 0; i < 500; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Simple, queryHash: $"simple-{i}",
+				timestamp: DateTime.UtcNow.AddMinutes(-1000 + i)));
+		for (int i = 0; i < 500; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.Aggregation, queryHash: $"agg-{i}",
+				timestamp: DateTime.UtcNow.AddMinutes(-500 + i)));
+		for (int i = 0; i < 100; i++)
+			tuner.RecordExecution(TestStatisticsFactory.Create(
+				type: QueryType.VectorSearch, queryHash: $"vec-{i}",
+				timestamp: DateTime.UtcNow.AddMinutes(-i)));
+
+		// Total inserted: 1100 → 100 oldest (Simple) should be evicted
+		var simpleRec = tuner.GetRecommendations(QueryType.Simple);
+		var aggRec = tuner.GetRecommendations(QueryType.Aggregation);
+		var vecRec = tuner.GetRecommendations(QueryType.VectorSearch);
+
+		// Simple should have lost 100 entries (evicted as oldest)
+		Assert.True(simpleRec.IsDataDriven);
+		Assert.Equal(400, simpleRec.SampleSize);
+
+		// Aggregation should be untouched
+		Assert.True(aggRec.IsDataDriven);
+		Assert.Equal(500, aggRec.SampleSize);
+
+		// VectorSearch should be untouched
+		Assert.True(vecRec.IsDataDriven);
+		Assert.Equal(100, vecRec.SampleSize);
+	}
+
 	#endregion
 
 	#region Recommendations: rule-based vs data-driven

--- a/code/Universe.Tests/Universe.Tests.csproj
+++ b/code/Universe.Tests/Universe.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<Nullable>disable</Nullable>
+		<LangVersion>14.0</LangVersion>
+		<IsPackable>false</IsPackable>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Universe\UniverseQuery.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/code/Universe/Builder/QueryBuilder.cs
+++ b/code/Universe/Builder/QueryBuilder.cs
@@ -3,17 +3,26 @@ using Universe.Builder.Strategies;
 
 namespace Universe.Builder;
 
-internal class UniverseBuilder(bool recordQueries) : IDisposable
+internal class UniverseBuilder : IDisposable
 {
-	private readonly QueryTuner _queryTuner = new();
-	private readonly QueryStrategySelector _strategySelector = new(new());
+	private readonly bool _recordQueries;
+	private readonly QueryTuner _queryTuner;
+	private readonly QueryStrategySelector _strategySelector;
 
 	public UniverseBuilder() : this(false)
 	{
 	}
 
-	public UniverseBuilder(bool recordQueries, QueryTuner queryTuner) : this(recordQueries)
+	public UniverseBuilder(bool recordQueries)
 	{
+		_recordQueries = recordQueries;
+		_queryTuner = new();
+		_strategySelector = new(_queryTuner);
+	}
+
+	public UniverseBuilder(bool recordQueries, QueryTuner queryTuner)
+	{
+		_recordQueries = recordQueries;
 		_queryTuner = queryTuner;
 		_strategySelector = new(_queryTuner);
 	}
@@ -478,7 +487,7 @@ internal class UniverseBuilder(bool recordQueries) : IDisposable
 		QueryContext singleContext = context.Value with { MaxItemCount = 1 };
 
 		IQueryExecutionStrategy strategy = _strategySelector.SelectStrategy(query, singleContext);
-		(Gravity gravity, IList<T> results) = await strategy.ExecuteAsync<T>(container, query, singleContext, recordQueries, _queryTuner);
+		(Gravity gravity, IList<T> results) = await strategy.ExecuteAsync<T>(container, query, singleContext, _recordQueries, _queryTuner);
 		T result = results.Count != 0 ? results.First() : default(T);
 		return (gravity, result);
 	}
@@ -487,7 +496,7 @@ internal class UniverseBuilder(bool recordQueries) : IDisposable
 	{
 		context ??= InferQueryContext(query);
 		IQueryExecutionStrategy strategy = _strategySelector.SelectStrategy(query, context.Value);
-		return await strategy.ExecuteAsync<T>(container, query, context.Value, recordQueries, _queryTuner);
+		return await strategy.ExecuteAsync<T>(container, query, context.Value, _recordQueries, _queryTuner);
 	}
 
 	internal QueryTuningRecommendations GetQueryRecommendations(QueryType queryType) => _queryTuner.GetRecommendations(queryType);

--- a/code/Universe/Builder/Strategies/QueryTuner.cs
+++ b/code/Universe/Builder/Strategies/QueryTuner.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 using Universe.Builder.Strategies.Storage;
 
 namespace Universe.Builder.Strategies;
@@ -84,7 +85,11 @@ internal sealed class QueryTuner : IDisposable
 	/// </summary>
 	public static string ComputeQueryHash(QueryContext context, string queryText)
 	{
-		string signature = $"{context.Type}|{queryText}";
+		// Normalize parameter names to produce consistent hashes for structurally identical queries.
+		// Parameter names contain dynamic CatalystIds (GUIDs) that vary per instance,
+		// so identical logical queries would otherwise get different hashes.
+		string normalizedQuery = Regex.Replace(queryText, @"@\w+", "@p");
+		string signature = $"{context.Type}|{normalizedQuery}";
 		byte[] bytes = Encoding.UTF8.GetBytes(signature);
 		byte[] hash = SHA256.HashData(bytes);
 		return Convert.ToBase64String(hash)[..16];

--- a/code/Universe/Builder/Strategies/QueryTuner.cs
+++ b/code/Universe/Builder/Strategies/QueryTuner.cs
@@ -39,15 +39,31 @@ internal sealed partial class QueryTuner : IDisposable
 		_partitions[stats.Type].Enqueue(stats);
 		Interlocked.Increment(ref _totalCount);
 
+		int evictionAttempts = 0;
 		while (Interlocked.CompareExchange(ref _totalCount, 0, 0) > MaxStoredExecutions)
 		{
 			if (TryEvictOldest())
+			{
 				Interlocked.Decrement(ref _totalCount);
-			else
+				evictionAttempts = 0;
+			}
+			else if (++evictionAttempts > MaxStoredExecutions)
+			{
+				// Queues are truly empty but _totalCount is stale — reconcile
+				Interlocked.Exchange(ref _totalCount, CountActual());
 				break;
+			}
 		}
 
 		_ = PersistAsync(stats);
+	}
+
+	private int CountActual()
+	{
+		int count = 0;
+		foreach (var kvp in _partitions)
+			count += kvp.Value.Count;
+		return count;
 	}
 
 	private bool TryEvictOldest()

--- a/code/Universe/Builder/Strategies/QueryTuner.cs
+++ b/code/Universe/Builder/Strategies/QueryTuner.cs
@@ -9,16 +9,22 @@ namespace Universe.Builder.Strategies;
 /// <summary>
 /// Provides query tuning recommendations based on query type and historical performance
 /// </summary>
-internal sealed class QueryTuner : IDisposable
+internal sealed partial class QueryTuner : IDisposable
 {
-	private readonly ConcurrentQueue<QueryExecutionStatistics> _recentExecutions;
+	private readonly ConcurrentDictionary<QueryType, ConcurrentQueue<QueryExecutionStatistics>> _partitions;
 	private readonly IQueryStatisticsStorage _storage;
+	private int _totalCount;
 	private const int MaxStoredExecutions = 1000;
 	private const int MinSampleSizeForRecommendations = 10;
 
+	[GeneratedRegex(@"@\w+")]
+	private static partial Regex ParameterNamePattern();
+
 	public QueryTuner(IQueryStatisticsStorage storage = null)
 	{
-		_recentExecutions = new ConcurrentQueue<QueryExecutionStatistics>();
+		_partitions = new ConcurrentDictionary<QueryType, ConcurrentQueue<QueryExecutionStatistics>>();
+		foreach (QueryType type in Enum.GetValues<QueryType>())
+			_partitions[type] = new ConcurrentQueue<QueryExecutionStatistics>();
 		_storage = storage ?? new InMemoryStatisticsStorage();
 
 		// Load persisted statistics on startup (async, don't block constructor)
@@ -30,12 +36,38 @@ internal sealed class QueryTuner : IDisposable
 	/// </summary>
 	public void RecordExecution(QueryExecutionStatistics stats)
 	{
-		_recentExecutions.Enqueue(stats);
-		while (_recentExecutions.Count > MaxStoredExecutions)
+		_partitions[stats.Type].Enqueue(stats);
+		Interlocked.Increment(ref _totalCount);
+
+		while (Interlocked.CompareExchange(ref _totalCount, 0, 0) > MaxStoredExecutions)
 		{
-			_recentExecutions.TryDequeue(out _);
+			if (TryEvictOldest())
+				Interlocked.Decrement(ref _totalCount);
+			else
+				break;
 		}
+
 		_ = PersistAsync(stats);
+	}
+
+	private bool TryEvictOldest()
+	{
+		QueryType? oldestType = null;
+		DateTime oldestTimestamp = DateTime.MaxValue;
+
+		foreach (var kvp in _partitions)
+		{
+			if (kvp.Value.TryPeek(out var front) && front.Timestamp < oldestTimestamp)
+			{
+				oldestTimestamp = front.Timestamp;
+				oldestType = kvp.Key;
+			}
+		}
+
+		if (oldestType.HasValue)
+			return _partitions[oldestType.Value].TryDequeue(out _);
+
+		return false;
 	}
 
 	private async Task PersistAsync(QueryExecutionStatistics stats)
@@ -58,7 +90,8 @@ internal sealed class QueryTuner : IDisposable
 		DateTime last24Hours = DateTime.UtcNow.AddHours(-24);
 
 		// Get relevant statistics from last 24 hours
-		List<QueryExecutionStatistics> relevantStats = [.. _recentExecutions.Where(s => s.Type == queryType && s.Timestamp >= last24Hours)];
+		List<QueryExecutionStatistics> relevantStats = [.. _partitions[queryType]
+			.Where(s => s.Timestamp >= last24Hours)];
 
 		// If insufficient data, fall back to rule-based recommendations
 		if (relevantStats.Count < MinSampleSizeForRecommendations)
@@ -88,7 +121,7 @@ internal sealed class QueryTuner : IDisposable
 		// Normalize parameter names to produce consistent hashes for structurally identical queries.
 		// Parameter names contain dynamic CatalystIds (GUIDs) that vary per instance,
 		// so identical logical queries would otherwise get different hashes.
-		string normalizedQuery = Regex.Replace(queryText, @"@\w+", "@p");
+		string normalizedQuery = ParameterNamePattern().Replace(queryText, "@p");
 		string signature = $"{context.Type}|{normalizedQuery}";
 		byte[] bytes = Encoding.UTF8.GetBytes(signature);
 		byte[] hash = SHA256.HashData(bytes);
@@ -221,7 +254,8 @@ internal sealed class QueryTuner : IDisposable
 			IList<QueryExecutionStatistics> persisted = await _storage.LoadRecentAsync(MaxStoredExecutions);
 			foreach (QueryExecutionStatistics stat in persisted)
 			{
-				_recentExecutions.Enqueue(stat);
+				_partitions[stat.Type].Enqueue(stat);
+				Interlocked.Increment(ref _totalCount);
 			}
 		}
 		catch (System.Exception ex)

--- a/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
+++ b/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
@@ -33,6 +33,9 @@ public sealed class FileStatisticsStorage : IQueryStatisticsStorage, IDisposable
 		string fullPath = Path.GetFullPath(path);
 		string allowedRoot = Path.GetFullPath(AppContext.BaseDirectory);
 
+		if (!allowedRoot.EndsWith(Path.DirectorySeparatorChar))
+			allowedRoot += Path.DirectorySeparatorChar;
+
 		if (!fullPath.StartsWith(allowedRoot, StringComparison.OrdinalIgnoreCase))
 			throw new UniverseException($"Storage path must be within the application directory '{allowedRoot}'.");
 

--- a/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
+++ b/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
@@ -14,18 +14,29 @@ public sealed class FileStatisticsStorage : IQueryStatisticsStorage, IDisposable
 	/// <summary>
 	/// Create a new file-based statistics storage
 	/// </summary>
-	/// <param name="filePath">Optional custom file path. If null, uses default location in the current working directory</param>
+	/// <param name="filePath">Optional custom file path. Must be within the application directory. If null, uses default location.</param>
 	public FileStatisticsStorage(string filePath = null)
 	{
-		_filePath = filePath ?? Path.Combine(
-			Directory.GetCurrentDirectory(),
+		_filePath = ValidateStoragePath(filePath ?? Path.Combine(
+			AppContext.BaseDirectory,
 			"query-statistics.json"
-		);
+		));
 
 		// Ensure directory exists
 		string directory = Path.GetDirectoryName(_filePath)!;
 		if (!Directory.Exists(directory))
 			Directory.CreateDirectory(directory);
+	}
+
+	private static string ValidateStoragePath(string path)
+	{
+		string fullPath = Path.GetFullPath(path);
+		string allowedRoot = Path.GetFullPath(AppContext.BaseDirectory);
+
+		if (!fullPath.StartsWith(allowedRoot, StringComparison.OrdinalIgnoreCase))
+			throw new UniverseException($"Storage path must be within the application directory '{allowedRoot}'.");
+
+		return fullPath;
 	}
 
 	/// <summary>
@@ -52,7 +63,7 @@ public sealed class FileStatisticsStorage : IQueryStatisticsStorage, IDisposable
 
 			await File.WriteAllTextAsync(_filePath, json);
 		}
-		catch (System.Exception ex)
+		catch (SystemException ex)
 		{
 			Trace.TraceWarning($"[UniverseQuery] File statistics save failed: {ex.Message}");
 		}

--- a/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
+++ b/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
@@ -66,6 +66,10 @@ public sealed class FileStatisticsStorage : IQueryStatisticsStorage, IDisposable
 
 			await File.WriteAllTextAsync(_filePath, json);
 		}
+		catch (JsonException ex)
+		{
+			Trace.TraceWarning($"[UniverseQuery] File statistics serialization failed: {ex.Message}");
+		}
 		catch (SystemException ex)
 		{
 			Trace.TraceWarning($"[UniverseQuery] File statistics save failed: {ex.Message}");

--- a/code/Universe/Builder/Strategies/Storage/SqliteStatisticsStorage.cs
+++ b/code/Universe/Builder/Strategies/Storage/SqliteStatisticsStorage.cs
@@ -102,6 +102,9 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		string fullPath = Path.GetFullPath(path);
 		string allowedRoot = Path.GetFullPath(AppContext.BaseDirectory);
 
+		if (!allowedRoot.EndsWith(Path.DirectorySeparatorChar))
+			allowedRoot += Path.DirectorySeparatorChar;
+
 		if (!fullPath.StartsWith(allowedRoot, StringComparison.OrdinalIgnoreCase))
 			throw new UniverseException($"Storage path must be within the application directory '{allowedRoot}'.");
 
@@ -125,7 +128,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		try
 		{
 			using SqliteCommand cmd = _connection.CreateCommand();
-			cmd.CommandText = "PRAGMA integrity_check";
+			cmd.CommandText = "PRAGMA quick_check";
 			string result = cmd.ExecuteScalar() as string;
 			if (result != "ok")
 				Trace.TraceWarning($"[UniverseQuery] SQLite integrity check failed: {result}");
@@ -265,10 +268,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		await FlushAsync();
 
 		if (!await _writeLock.WaitAsync(LockTimeout))
-		{
-			Trace.TraceWarning("[UniverseQuery] Lock acquisition timed out in LoadRecentAsync.");
-			return [];
-		}
+			throw new TimeoutException("Lock acquisition timed out in LoadRecentAsync.");
 		try
 		{
 			_selectRecentCommand.Parameters.Clear();
@@ -296,10 +296,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		long cutoffTimestamp = DateTimeOffset.UtcNow.Subtract(window).ToUnixTimeSeconds();
 
 		if (!await _writeLock.WaitAsync(LockTimeout))
-		{
-			Trace.TraceWarning("[UniverseQuery] Lock acquisition timed out in GetByQueryHashAsync.");
-			return [];
-		}
+			throw new TimeoutException("Lock acquisition timed out in GetByQueryHashAsync.");
 		try
 		{
 			_selectByHashCommand.Parameters.Clear();

--- a/code/Universe/Builder/Strategies/Storage/SqliteStatisticsStorage.cs
+++ b/code/Universe/Builder/Strategies/Storage/SqliteStatisticsStorage.cs
@@ -11,6 +11,7 @@ namespace Universe.Builder.Strategies.Storage;
 /// - Non-blocking fire-and-forget writes
 /// - Batched inserts for efficiency
 /// - Auto-cleanup of old data
+/// - Schema versioning for safe upgrades
 /// </summary>
 public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposable
 {
@@ -26,6 +27,8 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 	private bool _disposed;
 	private DateTime _lastCleanup = DateTime.UtcNow;
 	private static readonly TimeSpan CleanupInterval = TimeSpan.FromHours(1);
+	private static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(30);
+	private const int CurrentSchemaVersion = 1;
 
 	// Prepared statement cache
 	private SqliteCommand _insertCommand;
@@ -36,17 +39,21 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 	/// <summary>
 	/// Creates a new SQLite statistics storage
 	/// </summary>
-	/// <param name="dbPath">Path to the SQLite database file. If null, uses default location.</param>
-	/// <param name="retentionDays">Number of days to retain statistics. Older records are auto-cleaned.</param>
-	/// <param name="batchSize">Number of records to batch before flushing to database.</param>
-	/// <param name="flushIntervalSeconds">Interval in seconds between automatic flushes.</param>
+	/// <param name="dbPath">Path to the SQLite database file. Must be within the application directory. If null, uses default location.</param>
+	/// <param name="retentionDays">Number of days to retain statistics (minimum 1). Older records are auto-cleaned.</param>
+	/// <param name="batchSize">Number of records to batch before flushing to database (minimum 1).</param>
+	/// <param name="flushIntervalSeconds">Interval in seconds between automatic flushes (minimum 1).</param>
 	public SqliteStatisticsStorage(
 		string dbPath = null,
 		int retentionDays = 7,
 		int batchSize = 10,
 		int flushIntervalSeconds = 5)
 	{
-		_dbPath = dbPath ?? Path.Combine(AppContext.BaseDirectory, "universe-stats.db");
+		ArgumentOutOfRangeException.ThrowIfLessThan(retentionDays, 1);
+		ArgumentOutOfRangeException.ThrowIfLessThan(batchSize, 1);
+		ArgumentOutOfRangeException.ThrowIfLessThan(flushIntervalSeconds, 1);
+
+		_dbPath = ValidateStoragePath(dbPath ?? Path.Combine(AppContext.BaseDirectory, "universe-stats.db"));
 		_retentionDays = retentionDays;
 		_batchSize = batchSize;
 		_flushInterval = TimeSpan.FromSeconds(flushIntervalSeconds);
@@ -70,7 +77,10 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		// Enable WAL mode and other performance optimizations
 		ExecutePragmas();
 
-		// Initialize schema
+		// Run integrity check on startup
+		RunIntegrityCheck();
+
+		// Initialize schema with versioning
 		InitializeSchema();
 
 		// Prepare statements
@@ -87,6 +97,17 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 			_flushInterval);
 	}
 
+	internal static string ValidateStoragePath(string path)
+	{
+		string fullPath = Path.GetFullPath(path);
+		string allowedRoot = Path.GetFullPath(AppContext.BaseDirectory);
+
+		if (!fullPath.StartsWith(allowedRoot, StringComparison.OrdinalIgnoreCase))
+			throw new UniverseException($"Storage path must be within the application directory '{allowedRoot}'.");
+
+		return fullPath;
+	}
+
 	private void ExecutePragmas()
 	{
 		using SqliteCommand pragmaCommand = _connection.CreateCommand();
@@ -99,10 +120,30 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		pragmaCommand.ExecuteNonQuery();
 	}
 
+	private void RunIntegrityCheck()
+	{
+		try
+		{
+			using SqliteCommand cmd = _connection.CreateCommand();
+			cmd.CommandText = "PRAGMA integrity_check";
+			string result = cmd.ExecuteScalar() as string;
+			if (result != "ok")
+				Trace.TraceWarning($"[UniverseQuery] SQLite integrity check failed: {result}");
+		}
+		catch (SystemException ex)
+		{
+			Trace.TraceWarning($"[UniverseQuery] SQLite integrity check error: {ex.Message}");
+		}
+	}
+
 	private void InitializeSchema()
 	{
 		using SqliteCommand schemaCommand = _connection.CreateCommand();
 		schemaCommand.CommandText = """
+			CREATE TABLE IF NOT EXISTS schema_version (
+				version INTEGER NOT NULL
+			);
+
 			CREATE TABLE IF NOT EXISTS query_statistics (
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
 				query_hash TEXT NOT NULL,
@@ -121,8 +162,46 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 
 			CREATE INDEX IF NOT EXISTS idx_timestamp
 				ON query_statistics(timestamp);
+
+			CREATE INDEX IF NOT EXISTS idx_query_type_timestamp
+				ON query_statistics(query_type, timestamp DESC);
+
+			CREATE INDEX IF NOT EXISTS idx_strategy_used
+				ON query_statistics(strategy_used);
 			""";
 		schemaCommand.ExecuteNonQuery();
+
+		// Check and set schema version
+		using SqliteCommand versionCheck = _connection.CreateCommand();
+		versionCheck.CommandText = "SELECT version FROM schema_version LIMIT 1";
+		object result = versionCheck.ExecuteScalar();
+
+		if (result == null)
+		{
+			using SqliteCommand insertVersion = _connection.CreateCommand();
+			insertVersion.CommandText = "INSERT INTO schema_version (version) VALUES (@version)";
+			insertVersion.Parameters.AddWithValue("@version", CurrentSchemaVersion);
+			insertVersion.ExecuteNonQuery();
+		}
+		else
+		{
+			int existingVersion = Convert.ToInt32(result);
+			if (existingVersion < CurrentSchemaVersion)
+				MigrateSchema(existingVersion);
+		}
+	}
+
+	private void MigrateSchema(int fromVersion)
+	{
+		Trace.TraceInformation($"[UniverseQuery] Migrating SQLite schema from version {fromVersion} to {CurrentSchemaVersion}.");
+
+		// Future migrations go here, e.g.:
+		// if (fromVersion < 2) { ... apply v2 migration ... }
+
+		using SqliteCommand updateVersion = _connection.CreateCommand();
+		updateVersion.CommandText = "UPDATE schema_version SET version = @version";
+		updateVersion.Parameters.AddWithValue("@version", CurrentSchemaVersion);
+		updateVersion.ExecuteNonQuery();
 	}
 
 	private void PrepareStatements()
@@ -185,7 +264,11 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		// Flush pending writes first to ensure consistency
 		await FlushAsync();
 
-		await _writeLock.WaitAsync();
+		if (!await _writeLock.WaitAsync(LockTimeout))
+		{
+			Trace.TraceWarning("[UniverseQuery] Lock acquisition timed out in LoadRecentAsync.");
+			return [];
+		}
 		try
 		{
 			_selectRecentCommand.Parameters.Clear();
@@ -212,7 +295,11 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 
 		long cutoffTimestamp = DateTimeOffset.UtcNow.Subtract(window).ToUnixTimeSeconds();
 
-		await _writeLock.WaitAsync();
+		if (!await _writeLock.WaitAsync(LockTimeout))
+		{
+			Trace.TraceWarning("[UniverseQuery] Lock acquisition timed out in GetByQueryHashAsync.");
+			return [];
+		}
 		try
 		{
 			_selectByHashCommand.Parameters.Clear();
@@ -237,7 +324,11 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 
 		long cutoffTimestamp = DateTimeOffset.UtcNow.Subtract(olderThan).ToUnixTimeSeconds();
 
-		await _writeLock.WaitAsync();
+		if (!await _writeLock.WaitAsync(LockTimeout))
+		{
+			Trace.TraceWarning("[UniverseQuery] Lock acquisition timed out in ClearOldAsync.");
+			return;
+		}
 		try
 		{
 			_deleteOldCommand.Parameters.Clear();
@@ -265,7 +356,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 				{
 					hints = JsonSerializer.Deserialize<Dictionary<string, object>>(hintsJson);
 				}
-				catch (System.Exception ex)
+				catch (SystemException ex)
 				{
 					Trace.TraceWarning($"[UniverseQuery] Failed to deserialize query hints: {ex.Message}");
 				}
@@ -303,7 +394,13 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 
 		if (toWrite.Count == 0) return;
 
-		await _writeLock.WaitAsync();
+		if (!await _writeLock.WaitAsync(LockTimeout))
+		{
+			Trace.TraceWarning("[UniverseQuery] Lock acquisition timed out in FlushAsync. Re-queuing items.");
+			foreach (QueryExecutionStatistics item in toWrite)
+				_writeQueue.Enqueue(item);
+			return;
+		}
 		try
 		{
 			using SqliteTransaction transaction = _connection.BeginTransaction();
@@ -328,9 +425,13 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 
 			await transaction.CommitAsync();
 		}
-		catch (System.Exception ex)
+		catch (SystemException ex)
 		{
 			Trace.TraceWarning($"[UniverseQuery] SQLite flush failed: {ex.Message}");
+
+			// Re-enqueue failed items to prevent data loss
+			foreach (QueryExecutionStatistics item in toWrite)
+				_writeQueue.Enqueue(item);
 		}
 		finally
 		{
@@ -352,12 +453,22 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 	public void Dispose()
 	{
 		if (_disposed) return;
-		_disposed = true;
 
+		// Stop timer callbacks before final flush
+		_flushTimer?.Change(Timeout.Infinite, Timeout.Infinite);
 		_flushTimer?.Dispose();
 
-		// Final flush
-		FlushAsync().GetAwaiter().GetResult();
+		// Final flush BEFORE setting _disposed (FlushAsync checks _disposed and would skip)
+		try
+		{
+			FlushAsync().Wait(TimeSpan.FromSeconds(10));
+		}
+		catch (SystemException ex)
+		{
+			Trace.TraceWarning($"[UniverseQuery] Final flush during dispose failed: {ex.Message}");
+		}
+
+		_disposed = true;
 
 		_insertCommand?.Dispose();
 		_selectRecentCommand?.Dispose();

--- a/code/Universe/Builder/Strategies/Storage/SqliteStatisticsStorage.cs
+++ b/code/Universe/Builder/Strategies/Storage/SqliteStatisticsStorage.cs
@@ -89,11 +89,11 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		PrepareStatements();
 
 		// Run initial cleanup
-		_ = CleanupOldRecordsAsync();
+		FireAndForget(CleanupOldRecordsAsync);
 
 		// Start flush timer
 		_flushTimer = new Timer(
-			_ => _ = FlushAsync(),
+			_ => FireAndForget(FlushAsync),
 			null,
 			_flushInterval,
 			_flushInterval);
@@ -254,7 +254,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 
 		// Trigger flush if batch size reached
 		if (_writeQueue.Count >= _batchSize)
-			_ = FlushAsync();
+			FireAndForget(FlushAsync);
 
 		return Task.CompletedTask;
 	}
@@ -262,6 +262,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 	/// <summary>
 	/// Load recent statistics from the database
 	/// </summary>
+	/// <exception cref="TimeoutException">Thrown when the write lock cannot be acquired within the timeout period.</exception>
 	public async Task<IList<QueryExecutionStatistics>> LoadRecentAsync(int count)
 	{
 		if (_disposed) return [];
@@ -288,6 +289,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 	/// <summary>
 	/// Load statistics for a specific query hash within a time window
 	/// </summary>
+	/// <exception cref="TimeoutException">Thrown when the write lock cannot be acquired within the timeout period.</exception>
 	public async Task<IList<QueryExecutionStatistics>> GetByQueryHashAsync(string queryHash, TimeSpan window)
 	{
 		if (_disposed) return [];
@@ -317,6 +319,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 	/// <summary>
 	/// Clear old statistics (older than specified timespan)
 	/// </summary>
+	/// <exception cref="TimeoutException">Thrown when the write lock cannot be acquired within the timeout period.</exception>
 	public async Task ClearOldAsync(TimeSpan olderThan)
 	{
 		if (_disposed) return;
@@ -324,10 +327,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		long cutoffTimestamp = DateTimeOffset.UtcNow.Subtract(olderThan).ToUnixTimeSeconds();
 
 		if (!await _writeLock.WaitAsync(LockTimeout))
-		{
-			Trace.TraceWarning("[UniverseQuery] Lock acquisition timed out in ClearOldAsync.");
-			return;
-		}
+			throw new TimeoutException("Lock acquisition timed out in ClearOldAsync.");
 		try
 		{
 			_deleteOldCommand.Parameters.Clear();
@@ -395,9 +395,8 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 
 		if (!await _writeLock.WaitAsync(LockTimeout))
 		{
-			Trace.TraceWarning("[UniverseQuery] Lock acquisition timed out in FlushAsync. Re-queuing eligible items.");
 			RequeueWithRetryLimit(toWrite);
-			return;
+			throw new TimeoutException("Lock acquisition timed out in FlushAsync.");
 		}
 		try
 		{
@@ -422,6 +421,10 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 			}
 
 			await transaction.CommitAsync();
+
+			// Clear retry tracking for successfully persisted items
+			foreach (QueryExecutionStatistics stat in toWrite)
+				_retryCounts.TryRemove(stat, out _);
 		}
 		catch (SystemException ex)
 		{
@@ -436,7 +439,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		if (DateTime.UtcNow - _lastCleanup > CleanupInterval)
 		{
 			_lastCleanup = DateTime.UtcNow;
-			_ = CleanupOldRecordsAsync();
+			FireAndForget(CleanupOldRecordsAsync);
 		}
 	}
 
@@ -454,6 +457,21 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 				_retryCounts.TryRemove(item, out _);
 				Trace.TraceWarning($"[UniverseQuery] Dropping statistics for query '{item.QueryHash}' after {MaxFlushRetries} failed flush attempts.");
 			}
+		}
+	}
+
+	/// <summary>
+	/// Runs an async task fire-and-forget, logging any exceptions instead of leaving them unobserved.
+	/// </summary>
+	private static async void FireAndForget(Func<Task> action)
+	{
+		try
+		{
+			await action();
+		}
+		catch (System.Exception ex)
+		{
+			Trace.TraceWarning($"[UniverseQuery] Background operation failed: {ex.Message}");
 		}
 	}
 

--- a/code/Universe/Builder/Strategies/Storage/SqliteStatisticsStorage.cs
+++ b/code/Universe/Builder/Strategies/Storage/SqliteStatisticsStorage.cs
@@ -29,6 +29,8 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 	private static readonly TimeSpan CleanupInterval = TimeSpan.FromHours(1);
 	private static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(30);
 	private const int CurrentSchemaVersion = 1;
+	private const int MaxFlushRetries = 3;
+	private readonly ConcurrentDictionary<QueryExecutionStatistics, int> _retryCounts = new(ReferenceEqualityComparer.Instance);
 
 	// Prepared statement cache
 	private SqliteCommand _insertCommand;
@@ -393,9 +395,8 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 
 		if (!await _writeLock.WaitAsync(LockTimeout))
 		{
-			Trace.TraceWarning("[UniverseQuery] Lock acquisition timed out in FlushAsync. Re-queuing items.");
-			foreach (QueryExecutionStatistics item in toWrite)
-				_writeQueue.Enqueue(item);
+			Trace.TraceWarning("[UniverseQuery] Lock acquisition timed out in FlushAsync. Re-queuing eligible items.");
+			RequeueWithRetryLimit(toWrite);
 			return;
 		}
 		try
@@ -425,10 +426,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		catch (SystemException ex)
 		{
 			Trace.TraceWarning($"[UniverseQuery] SQLite flush failed: {ex.Message}");
-
-			// Re-enqueue failed items to prevent data loss
-			foreach (QueryExecutionStatistics item in toWrite)
-				_writeQueue.Enqueue(item);
+			RequeueWithRetryLimit(toWrite);
 		}
 		finally
 		{
@@ -439,6 +437,23 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
 		{
 			_lastCleanup = DateTime.UtcNow;
 			_ = CleanupOldRecordsAsync();
+		}
+	}
+
+	private void RequeueWithRetryLimit(List<QueryExecutionStatistics> items)
+	{
+		foreach (QueryExecutionStatistics item in items)
+		{
+			int retries = _retryCounts.AddOrUpdate(item, 1, (_, count) => count + 1);
+			if (retries <= MaxFlushRetries)
+			{
+				_writeQueue.Enqueue(item);
+			}
+			else
+			{
+				_retryCounts.TryRemove(item, out _);
+				Trace.TraceWarning($"[UniverseQuery] Dropping statistics for query '{item.QueryHash}' after {MaxFlushRetries} failed flush attempts.");
+			}
 		}
 	}
 

--- a/code/Universe/GalaxyBasic.cs
+++ b/code/Universe/GalaxyBasic.cs
@@ -65,7 +65,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
 		}
 		catch (CosmosException ex) when (ex.StatusCode != HttpStatusCode.Conflict)
 		{
-			throw;
+			throw new UniverseException($"A Cosmos DB error occurred. Status: {(int)ex.StatusCode}", ex);
 		}
 	}
 
@@ -125,7 +125,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
 		}
 		catch (CosmosException ex) when (ex.StatusCode != HttpStatusCode.Conflict)
 		{
-			throw;
+			throw new UniverseException($"A Cosmos DB error occurred. Status: {(int)ex.StatusCode}", ex);
 		}
 	}
 
@@ -144,7 +144,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
 		}
 		catch (CosmosException ex) when (ex.StatusCode != HttpStatusCode.NotFound)
 		{
-			throw;
+			throw new UniverseException($"A Cosmos DB error occurred. Status: {(int)ex.StatusCode}", ex);
 		}
 	}
 
@@ -202,7 +202,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
 		}
 		catch (CosmosException ex) when (ex.StatusCode != HttpStatusCode.NotFound)
 		{
-			throw;
+			throw new UniverseException($"A Cosmos DB error occurred. Status: {(int)ex.StatusCode}", ex);
 		}
 	}
 
@@ -236,7 +236,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
 		}
 		catch (CosmosException ex) when (ex.StatusCode != HttpStatusCode.NotFound)
 		{
-			throw;
+			throw new UniverseException($"A Cosmos DB error occurred. Status: {(int)ex.StatusCode}", ex);
 		}
 	}
 
@@ -256,7 +256,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
 		}
 		catch (CosmosException ex) when (ex.StatusCode != HttpStatusCode.NotFound)
 		{
-			throw;
+			throw new UniverseException($"A Cosmos DB error occurred. Status: {(int)ex.StatusCode}", ex);
 		}
 	}
 
@@ -273,7 +273,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
 		}
 		catch (CosmosException ex) when (ex.StatusCode != HttpStatusCode.NotFound)
 		{
-			throw;
+			throw new UniverseException($"A Cosmos DB error occurred. Status: {(int)ex.StatusCode}", ex);
 		}
 	}
 
@@ -290,7 +290,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
 		}
 		catch (CosmosException ex) when (ex.StatusCode != HttpStatusCode.NotFound)
 		{
-			throw;
+			throw new UniverseException($"A Cosmos DB error occurred. Status: {(int)ex.StatusCode}", ex);
 		}
 	}
 }

--- a/code/Universe/UniverseQuery.csproj
+++ b/code/Universe/UniverseQuery.csproj
@@ -40,6 +40,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="Universe.Tests" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.0" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -590,7 +590,7 @@
             <summary>
             Create a new file-based statistics storage
             </summary>
-            <param name="filePath">Optional custom file path. If null, uses default location in the current working directory</param>
+            <param name="filePath">Optional custom file path. Must be within the application directory. If null, uses default location.</param>
         </member>
         <member name="M:Universe.Builder.Strategies.Storage.FileStatisticsStorage.SaveAsync(Universe.Builder.Strategies.QueryExecutionStatistics)">
             <summary>
@@ -680,16 +680,17 @@
             - Non-blocking fire-and-forget writes
             - Batched inserts for efficiency
             - Auto-cleanup of old data
+            - Schema versioning for safe upgrades
             </summary>
         </member>
         <member name="M:Universe.Builder.Strategies.Storage.SqliteStatisticsStorage.#ctor(System.String,System.Int32,System.Int32,System.Int32)">
             <summary>
             Creates a new SQLite statistics storage
             </summary>
-            <param name="dbPath">Path to the SQLite database file. If null, uses default location.</param>
-            <param name="retentionDays">Number of days to retain statistics. Older records are auto-cleaned.</param>
-            <param name="batchSize">Number of records to batch before flushing to database.</param>
-            <param name="flushIntervalSeconds">Interval in seconds between automatic flushes.</param>
+            <param name="dbPath">Path to the SQLite database file. Must be within the application directory. If null, uses default location.</param>
+            <param name="retentionDays">Number of days to retain statistics (minimum 1). Older records are auto-cleaned.</param>
+            <param name="batchSize">Number of records to batch before flushing to database (minimum 1).</param>
+            <param name="flushIntervalSeconds">Interval in seconds between automatic flushes (minimum 1).</param>
         </member>
         <member name="M:Universe.Builder.Strategies.Storage.SqliteStatisticsStorage.SaveAsync(Universe.Builder.Strategies.QueryExecutionStatistics)">
             <summary>

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -712,15 +712,23 @@
             <summary>
             Load recent statistics from the database
             </summary>
+            <exception cref="T:System.TimeoutException">Thrown when the write lock cannot be acquired within the timeout period.</exception>
         </member>
         <member name="M:Universe.Builder.Strategies.Storage.SqliteStatisticsStorage.GetByQueryHashAsync(System.String,System.TimeSpan)">
             <summary>
             Load statistics for a specific query hash within a time window
             </summary>
+            <exception cref="T:System.TimeoutException">Thrown when the write lock cannot be acquired within the timeout period.</exception>
         </member>
         <member name="M:Universe.Builder.Strategies.Storage.SqliteStatisticsStorage.ClearOldAsync(System.TimeSpan)">
             <summary>
             Clear old statistics (older than specified timespan)
+            </summary>
+            <exception cref="T:System.TimeoutException">Thrown when the write lock cannot be acquired within the timeout period.</exception>
+        </member>
+        <member name="M:Universe.Builder.Strategies.Storage.SqliteStatisticsStorage.FireAndForget(System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            Runs an async task fire-and-forget, logging any exceptions instead of leaving them unobserved.
             </summary>
         </member>
         <member name="M:Universe.Builder.Strategies.Storage.SqliteStatisticsStorage.Dispose">

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -536,6 +536,17 @@
             Provides query tuning recommendations based on query type and historical performance
             </summary>
         </member>
+        <member name="M:Universe.Builder.Strategies.QueryTuner.ParameterNamePattern">
+            <remarks>
+            Pattern:<br/>
+            <code>@\\w+</code><br/>
+            Explanation:<br/>
+            <code>
+            ○ Match '@'.<br/>
+            ○ Match a word character atomically at least once.<br/>
+            </code>
+            </remarks>
+        </member>
         <member name="M:Universe.Builder.Strategies.QueryTuner.RecordExecution(Universe.Builder.Strategies.QueryExecutionStatistics)">
             <summary>
             Record a query execution for learning
@@ -1035,6 +1046,56 @@
             <param name="batchSize">Number of records to batch before flushing to database. Default is 10.</param>
             <param name="flushIntervalSeconds">Interval in seconds between automatic flushes. Default is 5 seconds.</param>
             <returns>UniverseOptions configured for SQLite persistence</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ParameterNamePattern_0">
+            <summary>Custom <see cref="T:System.Text.RegularExpressions.Regex"/>-derived type for the ParameterNamePattern method.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.ParameterNamePattern_0.Instance">
+            <summary>Cached, thread-safe singleton instance.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ParameterNamePattern_0.#ctor">
+            <summary>Initializes the instance.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ParameterNamePattern_0.RunnerFactory">
+            <summary>Provides a factory for creating <see cref="T:System.Text.RegularExpressions.RegexRunner"/> instances to be used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ParameterNamePattern_0.RunnerFactory.CreateInstance">
+            <summary>Creates an instance of a <see cref="T:System.Text.RegularExpressions.RegexRunner"/> used by methods on <see cref="T:System.Text.RegularExpressions.Regex"/>.</summary>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.ParameterNamePattern_0.RunnerFactory.Runner">
+            <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ParameterNamePattern_0.RunnerFactory.Runner.Scan(System.ReadOnlySpan{System.Char})">
+            <summary>Scan the <paramref name="inputSpan"/> starting from base.runtextstart for the next match.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ParameterNamePattern_0.RunnerFactory.Runner.TryFindNextPossibleStartingPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if a possible match was found; false if no more matches are possible.</returns>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.ParameterNamePattern_0.RunnerFactory.Runner.TryMatchAtCurrentPosition(System.ReadOnlySpan{System.Char})">
+            <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
+            <param name="inputSpan">The text being scanned by the regular expression.</param>
+            <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
+        </member>
+        <member name="T:System.Text.RegularExpressions.Generated.Utilities">
+            <summary>Helper methods used by generated <see cref="T:System.Text.RegularExpressions.Regex"/>-derived implementations.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_defaultTimeout">
+            <summary>Default timeout value set in <see cref="T:System.AppContext"/>, or <see cref="F:System.Text.RegularExpressions.Regex.InfiniteMatchTimeout"/> if none was set.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.s_hasTimeout">
+            <summary>Whether <see cref="F:System.Text.RegularExpressions.Generated.Utilities.s_defaultTimeout"/> is non-infinite.</summary>
+        </member>
+        <member name="M:System.Text.RegularExpressions.Generated.Utilities.IsWordChar(System.Char)">
+            <summary>Determines whether the character is part of the [\w] set.</summary>
+        </member>
+        <member name="F:System.Text.RegularExpressions.Generated.Utilities.WordCategoriesMask">
+            <summary>Provides a mask of Unicode categories that combine to form [\w].</summary>
+        </member>
+        <member name="P:System.Text.RegularExpressions.Generated.Utilities.WordCharBitmap">
+            <summary>Gets a bitmap for whether each character 0 through 127 is in [\w]</summary>
         </member>
     </members>
 </doc>

--- a/code/UniverseQuery.sln
+++ b/code/UniverseQuery.sln
@@ -7,20 +7,56 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DarkMatter", "DarkMatter\Da
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniverseQuery", "Universe\UniverseQuery.csproj", "{F4E71581-A400-4224-BAB2-984FF03210B0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Universe.Tests", "Universe.Tests\Universe.Tests.csproj", "{14EA6C7B-B2EE-40A9-96D1-1AC939965004}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Universe", "Universe", "{CFBB7EBF-39CC-D5B0-CF4E-A7D6CF52C4B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Debug|x64.Build.0 = Debug|Any CPU
+		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Debug|x86.Build.0 = Debug|Any CPU
 		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Release|x64.ActiveCfg = Release|Any CPU
+		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Release|x64.Build.0 = Release|Any CPU
+		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Release|x86.ActiveCfg = Release|Any CPU
+		{7B1E2F89-A898-4FFD-A7AC-6E38941AE5D0}.Release|x86.Build.0 = Release|Any CPU
 		{F4E71581-A400-4224-BAB2-984FF03210B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F4E71581-A400-4224-BAB2-984FF03210B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4E71581-A400-4224-BAB2-984FF03210B0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F4E71581-A400-4224-BAB2-984FF03210B0}.Debug|x64.Build.0 = Debug|Any CPU
+		{F4E71581-A400-4224-BAB2-984FF03210B0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F4E71581-A400-4224-BAB2-984FF03210B0}.Debug|x86.Build.0 = Debug|Any CPU
 		{F4E71581-A400-4224-BAB2-984FF03210B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4E71581-A400-4224-BAB2-984FF03210B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4E71581-A400-4224-BAB2-984FF03210B0}.Release|x64.ActiveCfg = Release|Any CPU
+		{F4E71581-A400-4224-BAB2-984FF03210B0}.Release|x64.Build.0 = Release|Any CPU
+		{F4E71581-A400-4224-BAB2-984FF03210B0}.Release|x86.ActiveCfg = Release|Any CPU
+		{F4E71581-A400-4224-BAB2-984FF03210B0}.Release|x86.Build.0 = Release|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Debug|x64.Build.0 = Debug|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Debug|x86.Build.0 = Debug|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Release|x64.ActiveCfg = Release|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Release|x64.Build.0 = Release|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Release|x86.ActiveCfg = Release|Any CPU
+		{14EA6C7B-B2EE-40A9-96D1-1AC939965004}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- **Partitioned data structure**: Replaced flat `ConcurrentQueue` with `ConcurrentDictionary<QueryType, ConcurrentQueue>` (7 pre-seeded partitions) so `GetRecommendations()` only scans entries of the requested type instead of all 1000 items
- **Global FIFO eviction**: `TryEvictOldest()` peeks all 7 partitions and dequeues from whichever has the oldest front entry, preserving the original cap behavior
- **Compiled regex**: Added `[GeneratedRegex]` source generator for `ComputeQueryHash`, eliminating runtime regex compilation
- **Thread-safe counter**: `Interlocked`-based `_totalCount` tracks global size without iterating all partitions

## Test plan
- [x] All 51 existing tests pass without modification
- [x] New: `GetRecommendations_OnlyConsidersEntriesOfRequestedType` — verifies partition isolation across 3 types + rule-based fallback for unrecorded type
- [x] New: `RecordExecution_GlobalCapAppliesAcrossAllTypes` — verifies global cap evicts oldest entries across types (500+500+100 → Simple loses 100)
- [x] New: `GetRecommendations_MixedTypes_UnrelatedTypeIsNotAffected` — confirms small partition (50 items) is faster than large partition (950 items)
- [x] 54/54 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit and performance tests and a new test project validating storage, tuning, persistence, and startup behavior.

* **Bug Fixes & Improvements**
  * Enforced storage path constraints and added integrity checks, schema versioning and migrations.
  * Improved concurrency handling with timeouts and retry/requeue behavior.
  * Enhanced error messages by wrapping lower-level exceptions.
  * Normalized query parameters for consistent hashing and tuning.
  * Exposed constructors to control query recording behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->