### PR TITLE
feature: Add fluent query builder (Orbit) API

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,23 @@ The Universe library provides a simple way to perform full-text search queries u
 
 See the [FULLTEXT_USAGE.md](https://github.com/kuromukira/universe/blob/dev/FULLTEXT_USAGE.md)
 
+## Fluent Query Builder (Orbit)
+The Universe library provides a fluent query builder called `Orbit<T>` as an alternative to the declarative `Cluster`/`Catalyst` syntax. Both approaches produce identical queries — use whichever style you prefer.
+
+```csharp
+// Fluent approach
+var (g, results) = await galaxy.Query()
+    .Select("id", "name", "price")
+    .Top(20)
+    .Cluster(c => c.Like("name", "%Test%").And().Lte("price", 50.0))
+    .Or()
+    .Cluster(c => c.Eq("code", "SPECIAL"))
+    .OrderByDescending("price")
+    .ToListAsync();
+```
+
+See the [FLUENT_QUERY_BUILDER.md](https://github.com/kuromukira/universe/blob/dev/docs/FLUENT_QUERY_BUILDER.md) for the complete API reference covering all operators, pagination, aggregation, vector search, full-text search, and more.
+
 ## Stored Procedures
 
 You can manage and execute Cosmos DB stored procedures using the `IGalaxyProcedure` interface. Inject your repository as `IGalaxyProcedure` and use its methods for full stored procedure lifecycle management and execution.

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-<Version>3.2.0</Version>
+<Version>3.3.0-preview.1</Version>

--- a/code/DarkMatter/Examples/Example13_QueryOptimization.cs
+++ b/code/DarkMatter/Examples/Example13_QueryOptimization.cs
@@ -121,7 +121,7 @@ public class Example13_QueryOptimization(IGalaxy<MyObjectVector> vectorGalaxy)
         if (recommendations.SuggestedHints != null && recommendations.SuggestedHints.Any())
         {
             Console.WriteLine("Suggested Hints:");
-            foreach (var hint in recommendations.SuggestedHints)
+            foreach (KeyValuePair<string, object> hint in recommendations.SuggestedHints)
             {
                 Console.WriteLine($"  {hint.Key} = {hint.Value}");
             }

--- a/code/Universe.Tests/Builder/OrbitQueryTests.cs
+++ b/code/Universe.Tests/Builder/OrbitQueryTests.cs
@@ -1,0 +1,465 @@
+using System.Text.RegularExpressions;
+using Universe.Builder;
+using Universe.Builder.Options;
+using Universe.Interfaces;
+using Xunit;
+
+namespace Universe.Tests.Builder;
+
+/// <summary>
+/// Tests that the fluent Orbit builder generates identical SQL to the declarative Cluster/Catalyst API.
+/// </summary>
+public sealed class OrbitQueryTests : IDisposable
+{
+    private readonly UniverseBuilder _builder = new(recordQueries: true);
+
+    public void Dispose() => _builder.Dispose();
+
+    private static readonly Regex ParameterNormalizer = new(@"@\w+", RegexOptions.Compiled);
+
+    private static string Normalize(string sql) =>
+        ParameterNormalizer.Replace(sql, "@p");
+
+    #region Single Cluster Tests
+
+    [Fact]
+    public void SingleCluster_SingleCatalyst()
+    {
+        // Declarative
+        List<Cluster> declarative = [new([new("name", "test")])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        // Fluent
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.Eq("name", "test"));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void SingleCluster_MultipleAndCatalysts()
+    {
+        List<Cluster> declarative = [new([
+            new("name", "test"),
+            new("price", 50.0, Operator: Q.Operator.Gt)
+        ])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.Eq("name", "test").And().Gt("price", 50.0));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void SingleCluster_MixedAndOrCatalysts()
+    {
+        List<Cluster> declarative = [new([
+            new("name", "test"),
+            new("code", "ABC", Where: Q.Where.Or),
+            new("price", 10.0, Operator: Q.Operator.Gte)
+        ])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.Eq("name", "test").Or().Eq("code", "ABC").And().Gte("price", 10.0));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    #endregion
+
+    #region Multiple Cluster Tests
+
+    [Fact]
+    public void MultipleClusters_WithAnd()
+    {
+        List<Cluster> declarative = [
+            new([new("name", "test")]),
+            new([new("code", "ABC")], Where: Q.Where.And)
+        ];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.Eq("name", "test"))
+             .And()
+             .Cluster(c => c.Eq("code", "ABC"));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void MultipleClusters_WithOr()
+    {
+        List<Cluster> declarative = [
+            new([new("name", "test")]),
+            new([new("code", "ABC")], Where: Q.Where.Or)
+        ];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.Eq("name", "test"))
+             .Or()
+             .Cluster(c => c.Eq("code", "ABC"));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    #endregion
+
+    #region Column Selection Tests
+
+    [Fact]
+    public void SelectColumns_WithTop()
+    {
+        List<Cluster> declarative = [new([new("name", "test")])];
+        ColumnOptions colOpts = new(Names: ["id", "name", "price"], Top: 10);
+        var expected = _builder.CreateQuery(declarative, colOpts).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Select("id", "name", "price").Top(10)
+             .Cluster(c => c.Eq("name", "test"));
+        var (clusters, fluentColOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void Distinct()
+    {
+        List<Cluster> declarative = [new([new("category", "Electronics")])];
+        ColumnOptions colOpts = new(Names: ["category"], IsDistinct: true);
+        var expected = _builder.CreateQuery(declarative, colOpts).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Select("category").Distinct()
+             .Cluster(c => c.Eq("category", "Electronics"));
+        var (clusters, fluentColOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    #endregion
+
+    #region Sorting Tests
+
+    [Fact]
+    public void OrderByDescending()
+    {
+        List<Cluster> declarative = [new([new("name", "test")])];
+        List<Sorting.Option> sort = [new("price", Sorting.Direction.DESC)];
+        var expected = _builder.CreateQuery(declarative, sorting: sort).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.Eq("name", "test")).OrderByDescending("price");
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    #endregion
+
+    #region Operator Tests
+
+    [Fact]
+    public void LikeOperator()
+    {
+        List<Cluster> declarative = [new([new("name", "%Test%", Operator: Q.Operator.Like)])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.Like("name", "%Test%"));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void DefinedOperator()
+    {
+        List<Cluster> declarative = [new([
+            new("name", Operator: Q.Operator.Defined),
+            new("description", Operator: Q.Operator.NotDefined)
+        ])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.Defined("name").And().NotDefined("description"));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void ContainsOperator()
+    {
+        string[] values = ["Electronics", "Books"];
+        List<Cluster> declarative = [new([new("category", values, Operator: Q.Operator.Contains)])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.Contains("category", values));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void NotContainsOperator()
+    {
+        string[] values = ["Blocked1", "Blocked2"];
+        List<Cluster> declarative = [new([new("code", values, Operator: Q.Operator.NotContains)])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.NotContains("code", values));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void InOperator()
+    {
+        List<Cluster> declarative = [new([new("links", "someValue", Operator: Q.Operator.In)])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.In("links", "someValue"));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void NotInOperator()
+    {
+        List<Cluster> declarative = [new([new("tags", "removed", Operator: Q.Operator.NotIn)])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.NotIn("tags", "removed"));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void LenOperator()
+    {
+        List<Cluster> declarative = [new([new("items", 5, Operator: Q.Operator.Len)])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.Len("items", 5));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void NotLikeOperator()
+    {
+        List<Cluster> declarative = [new([new("name", "%skip%", Operator: Q.Operator.NotLike)])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.NotLike("name", "%skip%"));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    #endregion
+
+    #region Aggregation Tests
+
+    [Fact]
+    public void Aggregation_WithGroupBy()
+    {
+        List<Cluster> declarative = [new([new("status", "active")])];
+        ColumnOptions colOpts = new(
+            Names: ["category"],
+            Aggregates: [
+                new("price", Q.Aggregate.Sum),
+                new("id", Q.Aggregate.Count)
+            ]);
+        List<string> group = ["category"];
+        var expected = _builder.CreateQuery(declarative, colOpts, groups: group).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Select("category")
+             .Aggregate("price", Q.Aggregate.Sum)
+             .Aggregate("id", Q.Aggregate.Count)
+             .GroupBy("category")
+             .Cluster(c => c.Eq("status", "active"));
+        var (clusters, fluentColOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    #endregion
+
+    #region No Clusters Tests
+
+    [Fact]
+    public void NoClusters_SelectAll()
+    {
+        var expected = _builder.CreateQuery(null).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    #endregion
+
+    #region Vector Search Tests
+
+    [Fact]
+    public void VectorDistance()
+    {
+        float[] vector = [0.1f, 0.2f, 0.3f];
+        List<Cluster> declarative = [new([new("embedding", vector, Operator: Q.Operator.VectorDistance)])];
+        ColumnOptions colOpts = new(Names: ["name", "description"], Top: 5);
+        var expected = _builder.CreateQuery(declarative, colOpts).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Select("name", "description").Top(5)
+             .Cluster(c => c.VectorDistance("embedding", vector));
+        var (clusters, fluentColOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    #endregion
+
+    #region Full-Text Search Tests
+
+    [Fact]
+    public void FTContains()
+    {
+        List<Cluster> declarative = [new([new("description", "machine", Operator: Q.Operator.FTContains)])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.FTContains("description", "machine"));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void FTContainsAll()
+    {
+        string[] keywords = ["machine", "learning"];
+        List<Cluster> declarative = [new([new("description", keywords, Operator: Q.Operator.FTContainsAll)])];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.FTContainsAll("description", keywords));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    #endregion
+
+    #region Complex Multi-Cluster Tests
+
+    [Fact]
+    public void ComplexMultiCluster_MirrorsExample4()
+    {
+        // Mirrors Example4_ComplexFiltering pattern
+        List<Cluster> declarative = [
+            new(Catalysts: [
+                new("name", "%Test%", Operator: Q.Operator.Like),
+                new("addedOn", "2025-01-01", Operator: Q.Operator.Gte, Where: Q.Where.And),
+                new("price", 50.0, Operator: Q.Operator.Lte, Where: Q.Where.And)
+            ], Where: Q.Where.And),
+            new(Catalysts: [
+                new("code", "SPECIAL", Where: Q.Where.Or),
+                new("category", "Premium", Where: Q.Where.And)
+            ])
+        ];
+        ColumnOptions colOpts = new(Names: ["id", "name", "price", "category"], Top: 20);
+        List<Sorting.Option> sort = [new("price", Sorting.Direction.DESC)];
+        var expected = _builder.CreateQuery(declarative, colOpts, sort).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Select("id", "name", "price", "category")
+             .Top(20)
+             .Cluster(c => c
+                 .Like("name", "%Test%")
+                 .And().Gte("addedOn", "2025-01-01")
+                 .And().Lte("price", 50.0))
+             .Cluster(c => c
+                 .Eq("code", "SPECIAL")
+                 .And().Eq("category", "Premium"))
+             .OrderByDescending("price");
+        var (clusters, fluentColOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    [Fact]
+    public void ThreeClusters_MixedLogic()
+    {
+        List<Cluster> declarative = [
+            new([new("status", "active")]),
+            new([new("priority", 1, Operator: Q.Operator.Gte)], Where: Q.Where.And),
+            new([new("archived", Operator: Q.Operator.NotDefined)], Where: Q.Where.Or)
+        ];
+        var expected = _builder.CreateQuery(declarative).QueryText;
+
+        var orbit = new Orbit<TestEntity>(null);
+        orbit.Cluster(c => c.Eq("status", "active"))
+             .And()
+             .Cluster(c => c.Gte("priority", 1))
+             .Or()
+             .Cluster(c => c.NotDefined("archived"));
+        var (clusters, colOpts, sorting, groups) = orbit.Build();
+        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+        Assert.Equal(Normalize(expected), Normalize(actual));
+    }
+
+    #endregion
+}
+
+/// <summary>Minimal ICosmicEntity for test purposes.</summary>
+internal record TestEntity : ICosmicEntity
+{
+    public string id { get; set; } = Guid.NewGuid().ToString();
+    public DateTime AddedOn { get; set; } = DateTime.UtcNow;
+    public DateTime? ModifiedOn { get; set; }
+    public long CountAggregate { get; set; }
+}

--- a/code/Universe.Tests/Builder/OrbitQueryTests.cs
+++ b/code/Universe.Tests/Builder/OrbitQueryTests.cs
@@ -404,6 +404,8 @@ public sealed class OrbitQueryTests : IDisposable
                 new("addedOn", "2025-01-01", Operator: Q.Operator.Gte, Where: Q.Where.And),
                 new("price", 50.0, Operator: Q.Operator.Lte, Where: Q.Where.And)
             ], Where: Q.Where.And),
+            // Note: The first catalyst's Where value (Q.Where.Or) is ignored by QueryBuilder —
+            // only subsequent catalysts' Where values are used as connectors within the cluster.
             new(Catalysts: [
                 new("code", "SPECIAL", Where: Q.Where.Or),
                 new("category", "Premium", Where: Q.Where.And)

--- a/code/Universe.Tests/Builder/OrbitQueryTests.cs
+++ b/code/Universe.Tests/Builder/OrbitQueryTests.cs
@@ -27,13 +27,13 @@ public sealed class OrbitQueryTests : IDisposable
     {
         // Declarative
         List<Cluster> declarative = [new([new("name", "test")])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
         // Fluent
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.Eq("name", "test"));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -45,12 +45,12 @@ public sealed class OrbitQueryTests : IDisposable
             new("name", "test"),
             new("price", 50.0, Operator: Q.Operator.Gt)
         ])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.Eq("name", "test").And().Gt("price", 50.0));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -63,12 +63,12 @@ public sealed class OrbitQueryTests : IDisposable
             new("code", "ABC", Where: Q.Where.Or),
             new("price", 10.0, Operator: Q.Operator.Gte)
         ])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.Eq("name", "test").Or().Eq("code", "ABC").And().Gte("price", 10.0));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -84,14 +84,14 @@ public sealed class OrbitQueryTests : IDisposable
             new([new("name", "test")]),
             new([new("code", "ABC")], Where: Q.Where.And)
         ];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.Eq("name", "test"))
              .And()
              .Cluster(c => c.Eq("code", "ABC"));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -103,14 +103,14 @@ public sealed class OrbitQueryTests : IDisposable
             new([new("name", "test")]),
             new([new("code", "ABC")], Where: Q.Where.Or)
         ];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.Eq("name", "test"))
              .Or()
              .Cluster(c => c.Eq("code", "ABC"));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -124,13 +124,13 @@ public sealed class OrbitQueryTests : IDisposable
     {
         List<Cluster> declarative = [new([new("name", "test")])];
         ColumnOptions colOpts = new(Names: ["id", "name", "price"], Top: 10);
-        var expected = _builder.CreateQuery(declarative, colOpts).QueryText;
+        string expected = _builder.CreateQuery(declarative, colOpts).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Select("id", "name", "price").Top(10)
              .Cluster(c => c.Eq("name", "test"));
-        var (clusters, fluentColOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? fluentColOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -140,13 +140,13 @@ public sealed class OrbitQueryTests : IDisposable
     {
         List<Cluster> declarative = [new([new("category", "Electronics")])];
         ColumnOptions colOpts = new(Names: ["category"], IsDistinct: true);
-        var expected = _builder.CreateQuery(declarative, colOpts).QueryText;
+        string expected = _builder.CreateQuery(declarative, colOpts).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Select("category").Distinct()
              .Cluster(c => c.Eq("category", "Electronics"));
-        var (clusters, fluentColOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? fluentColOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -160,12 +160,12 @@ public sealed class OrbitQueryTests : IDisposable
     {
         List<Cluster> declarative = [new([new("name", "test")])];
         List<Sorting.Option> sort = [new("price", Sorting.Direction.DESC)];
-        var expected = _builder.CreateQuery(declarative, sorting: sort).QueryText;
+        string expected = _builder.CreateQuery(declarative, sorting: sort).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.Eq("name", "test")).OrderByDescending("price");
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -178,12 +178,12 @@ public sealed class OrbitQueryTests : IDisposable
     public void LikeOperator()
     {
         List<Cluster> declarative = [new([new("name", "%Test%", Operator: Q.Operator.Like)])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.Like("name", "%Test%"));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -195,12 +195,12 @@ public sealed class OrbitQueryTests : IDisposable
             new("name", Operator: Q.Operator.Defined),
             new("description", Operator: Q.Operator.NotDefined)
         ])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.Defined("name").And().NotDefined("description"));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -210,12 +210,12 @@ public sealed class OrbitQueryTests : IDisposable
     {
         string[] values = ["Electronics", "Books"];
         List<Cluster> declarative = [new([new("category", values, Operator: Q.Operator.Contains)])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.Contains("category", values));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -225,12 +225,12 @@ public sealed class OrbitQueryTests : IDisposable
     {
         string[] values = ["Blocked1", "Blocked2"];
         List<Cluster> declarative = [new([new("code", values, Operator: Q.Operator.NotContains)])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.NotContains("code", values));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -239,12 +239,12 @@ public sealed class OrbitQueryTests : IDisposable
     public void InOperator()
     {
         List<Cluster> declarative = [new([new("links", "someValue", Operator: Q.Operator.In)])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.In("links", "someValue"));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -253,12 +253,12 @@ public sealed class OrbitQueryTests : IDisposable
     public void NotInOperator()
     {
         List<Cluster> declarative = [new([new("tags", "removed", Operator: Q.Operator.NotIn)])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.NotIn("tags", "removed"));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -267,12 +267,12 @@ public sealed class OrbitQueryTests : IDisposable
     public void LenOperator()
     {
         List<Cluster> declarative = [new([new("items", 5, Operator: Q.Operator.Len)])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.Len("items", 5));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -281,12 +281,12 @@ public sealed class OrbitQueryTests : IDisposable
     public void NotLikeOperator()
     {
         List<Cluster> declarative = [new([new("name", "%skip%", Operator: Q.Operator.NotLike)])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.NotLike("name", "%skip%"));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -306,16 +306,16 @@ public sealed class OrbitQueryTests : IDisposable
                 new("id", Q.Aggregate.Count)
             ]);
         List<string> group = ["category"];
-        var expected = _builder.CreateQuery(declarative, colOpts, groups: group).QueryText;
+        string expected = _builder.CreateQuery(declarative, colOpts, groups: group).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Select("category")
              .Aggregate("price", Q.Aggregate.Sum)
              .Aggregate("id", Q.Aggregate.Count)
              .GroupBy("category")
              .Cluster(c => c.Eq("status", "active"));
-        var (clusters, fluentColOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? fluentColOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -327,11 +327,11 @@ public sealed class OrbitQueryTests : IDisposable
     [Fact]
     public void NoClusters_SelectAll()
     {
-        var expected = _builder.CreateQuery(null).QueryText;
+        string expected = _builder.CreateQuery(null).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -346,13 +346,13 @@ public sealed class OrbitQueryTests : IDisposable
         float[] vector = [0.1f, 0.2f, 0.3f];
         List<Cluster> declarative = [new([new("embedding", vector, Operator: Q.Operator.VectorDistance)])];
         ColumnOptions colOpts = new(Names: ["name", "description"], Top: 5);
-        var expected = _builder.CreateQuery(declarative, colOpts).QueryText;
+        string expected = _builder.CreateQuery(declarative, colOpts).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Select("name", "description").Top(5)
              .Cluster(c => c.VectorDistance("embedding", vector));
-        var (clusters, fluentColOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? fluentColOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -365,12 +365,12 @@ public sealed class OrbitQueryTests : IDisposable
     public void FTContains()
     {
         List<Cluster> declarative = [new([new("description", "machine", Operator: Q.Operator.FTContains)])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.FTContains("description", "machine"));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -380,12 +380,12 @@ public sealed class OrbitQueryTests : IDisposable
     {
         string[] keywords = ["machine", "learning"];
         List<Cluster> declarative = [new([new("description", keywords, Operator: Q.Operator.FTContainsAll)])];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.FTContainsAll("description", keywords));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -411,9 +411,9 @@ public sealed class OrbitQueryTests : IDisposable
         ];
         ColumnOptions colOpts = new(Names: ["id", "name", "price", "category"], Top: 20);
         List<Sorting.Option> sort = [new("price", Sorting.Direction.DESC)];
-        var expected = _builder.CreateQuery(declarative, colOpts, sort).QueryText;
+        string expected = _builder.CreateQuery(declarative, colOpts, sort).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Select("id", "name", "price", "category")
              .Top(20)
              .Cluster(c => c
@@ -424,8 +424,8 @@ public sealed class OrbitQueryTests : IDisposable
                  .Eq("code", "SPECIAL")
                  .And().Eq("category", "Premium"))
              .OrderByDescending("price");
-        var (clusters, fluentColOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? fluentColOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, fluentColOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }
@@ -438,16 +438,16 @@ public sealed class OrbitQueryTests : IDisposable
             new([new("priority", 1, Operator: Q.Operator.Gte)], Where: Q.Where.And),
             new([new("archived", Operator: Q.Operator.NotDefined)], Where: Q.Where.Or)
         ];
-        var expected = _builder.CreateQuery(declarative).QueryText;
+        string expected = _builder.CreateQuery(declarative).QueryText;
 
-        var orbit = new Orbit<TestEntity>(null);
+        Orbit<TestEntity> orbit = new Orbit<TestEntity>(null);
         orbit.Cluster(c => c.Eq("status", "active"))
              .And()
              .Cluster(c => c.Gte("priority", 1))
              .Or()
              .Cluster(c => c.NotDefined("archived"));
-        var (clusters, colOpts, sorting, groups) = orbit.Build();
-        var actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+        (IReadOnlyList<Cluster> clusters, ColumnOptions? colOpts, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = orbit.Build();
+        string actual = _builder.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
 
         Assert.Equal(Normalize(expected), Normalize(actual));
     }

--- a/code/Universe.Tests/Storage/FileStatisticsStorageTests.cs
+++ b/code/Universe.Tests/Storage/FileStatisticsStorageTests.cs
@@ -30,8 +30,8 @@ public sealed class FileStatisticsStorageTests : IDisposable
     [Fact]
     public async Task SaveAndLoad_RoundTrip_AllFieldsPreserved()
     {
-        var hints = new Dictionary<string, object> { ["MaxItemCount"] = 50 };
-        var stat = TestStatisticsFactory.Create(
+        Dictionary<string, object> hints = new Dictionary<string, object> { ["MaxItemCount"] = 50 };
+        QueryExecutionStatistics stat = TestStatisticsFactory.Create(
             queryHash: "file-abc",
             type: QueryType.Aggregation,
             ru: 33.3,
@@ -43,10 +43,10 @@ public sealed class FileStatisticsStorageTests : IDisposable
             hintsUsed: hints);
 
         await _storage.SaveAsync(stat);
-        var loaded = await _storage.LoadRecentAsync(10);
+        IList<QueryExecutionStatistics> loaded = await _storage.LoadRecentAsync(10);
 
         Assert.Single(loaded);
-        var result = loaded[0];
+        QueryExecutionStatistics result = loaded[0];
         Assert.Equal("file-abc", result.QueryHash);
         Assert.Equal(QueryType.Aggregation, result.Type);
         Assert.Equal(33.3, result.RU);
@@ -66,7 +66,7 @@ public sealed class FileStatisticsStorageTests : IDisposable
                 timestamp: DateTime.UtcNow.AddMinutes(-i)));
         }
 
-        var loaded = await _storage.LoadRecentAsync(5);
+        IList<QueryExecutionStatistics> loaded = await _storage.LoadRecentAsync(5);
 
         Assert.Equal(5, loaded.Count);
         // Most recent first
@@ -84,7 +84,7 @@ public sealed class FileStatisticsStorageTests : IDisposable
                 timestamp: DateTime.UtcNow.AddSeconds(-i)));
         }
 
-        var loaded = await _storage.LoadRecentAsync(2000);
+        IList<QueryExecutionStatistics> loaded = await _storage.LoadRecentAsync(2000);
 
         Assert.Equal(1000, loaded.Count);
         // Should keep the most recent 1000
@@ -98,12 +98,12 @@ public sealed class FileStatisticsStorageTests : IDisposable
         await File.WriteAllTextAsync(_filePath, "{ this is not valid json [[[");
 
         // LoadRecentAsync should return empty (not throw)
-        var loaded = await _storage.LoadRecentAsync(10);
+        IList<QueryExecutionStatistics> loaded = await _storage.LoadRecentAsync(10);
         Assert.Empty(loaded);
 
         // Should be able to save new data after recovery
         await _storage.SaveAsync(TestStatisticsFactory.Create(queryHash: "recovered"));
-        var loadedAfter = await _storage.LoadRecentAsync(10);
+        IList<QueryExecutionStatistics> loadedAfter = await _storage.LoadRecentAsync(10);
         Assert.Single(loadedAfter);
         Assert.Equal("recovered", loadedAfter[0].QueryHash);
     }
@@ -112,7 +112,7 @@ public sealed class FileStatisticsStorageTests : IDisposable
     public void CustomPath_IsAllowed()
     {
         string customPath = Path.Combine(AppContext.BaseDirectory, "custom-dir", $"universe-test-{Guid.NewGuid()}.json");
-        using var storage = new FileStatisticsStorage(customPath);
+        using FileStatisticsStorage storage = new FileStatisticsStorage(customPath);
         storage.Dispose();
         try
         {
@@ -153,9 +153,9 @@ public sealed class FileStatisticsStorageTests : IDisposable
         foreach (int scale in scales)
         {
             string filePath = Path.Combine(AppContext.BaseDirectory, $"perf-file-{scale}-{Guid.NewGuid()}.json");
-            using var storage = new FileStatisticsStorage(filePath);
+            using FileStatisticsStorage storage = new FileStatisticsStorage(filePath);
 
-            var sw = Stopwatch.StartNew();
+            Stopwatch sw = Stopwatch.StartNew();
             for (int i = 0; i < scale; i++)
             {
                 await storage.SaveAsync(TestStatisticsFactory.Create(

--- a/code/Universe.Tests/Storage/InMemoryStatisticsStorageTests.cs
+++ b/code/Universe.Tests/Storage/InMemoryStatisticsStorageTests.cs
@@ -1,3 +1,4 @@
+using Universe.Builder.Strategies;
 using Universe.Builder.Strategies.Storage;
 using Universe.Tests.Helpers;
 using Xunit;
@@ -9,8 +10,8 @@ public sealed class InMemoryStatisticsStorageTests
     [Fact]
     public async Task SaveAsync_ReturnsCompletedTask()
     {
-        var storage = new InMemoryStatisticsStorage();
-        var task = storage.SaveAsync(TestStatisticsFactory.Create());
+        InMemoryStatisticsStorage storage = new InMemoryStatisticsStorage();
+        Task task = storage.SaveAsync(TestStatisticsFactory.Create());
 
         Assert.True(task.IsCompleted);
         await task; // should not throw
@@ -19,8 +20,8 @@ public sealed class InMemoryStatisticsStorageTests
     [Fact]
     public async Task LoadRecentAsync_ReturnsEmpty()
     {
-        var storage = new InMemoryStatisticsStorage();
-        var result = await storage.LoadRecentAsync(100);
+        InMemoryStatisticsStorage storage = new InMemoryStatisticsStorage();
+        IList<QueryExecutionStatistics> result = await storage.LoadRecentAsync(100);
 
         Assert.Empty(result);
     }
@@ -28,8 +29,8 @@ public sealed class InMemoryStatisticsStorageTests
     [Fact]
     public async Task GetByQueryHashAsync_ReturnsEmpty()
     {
-        var storage = new InMemoryStatisticsStorage();
-        var result = await storage.GetByQueryHashAsync("anyhash", TimeSpan.FromHours(1));
+        InMemoryStatisticsStorage storage = new InMemoryStatisticsStorage();
+        IList<QueryExecutionStatistics> result = await storage.GetByQueryHashAsync("anyhash", TimeSpan.FromHours(1));
 
         Assert.Empty(result);
     }
@@ -37,7 +38,7 @@ public sealed class InMemoryStatisticsStorageTests
     [Fact]
     public async Task ClearOldAsync_Completes()
     {
-        var storage = new InMemoryStatisticsStorage();
+        InMemoryStatisticsStorage storage = new InMemoryStatisticsStorage();
         await storage.ClearOldAsync(TimeSpan.FromDays(1)); // should not throw
     }
 }

--- a/code/Universe.Tests/Storage/SqliteStatisticsStorageTests.cs
+++ b/code/Universe.Tests/Storage/SqliteStatisticsStorageTests.cs
@@ -36,8 +36,8 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
     [Fact]
     public async Task SaveAndLoad_RoundTrip_AllFieldsPreserved()
     {
-        var hints = new Dictionary<string, object> { ["MaxItemCount"] = 50 };
-        var stat = TestStatisticsFactory.Create(
+        Dictionary<string, object> hints = new Dictionary<string, object> { ["MaxItemCount"] = 50 };
+        QueryExecutionStatistics stat = TestStatisticsFactory.Create(
             queryHash: "abc123",
             type: QueryType.VectorSearch,
             ru: 42.5,
@@ -52,7 +52,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
         IList<QueryExecutionStatistics> loaded = await _storage.LoadRecentAsync(10);
 
         Assert.Single(loaded);
-        var result = loaded[0];
+        QueryExecutionStatistics result = loaded[0];
         Assert.Equal("abc123", result.QueryHash);
         Assert.Equal(QueryType.VectorSearch, result.Type);
         Assert.Equal(42.5, result.RU);
@@ -66,9 +66,9 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
     [Fact]
     public async Task SaveAndLoad_NullHintsAndStrategy_Preserved()
     {
-        var stat = TestStatisticsFactory.Create(strategyUsed: null, hintsUsed: null);
+        QueryExecutionStatistics stat = TestStatisticsFactory.Create(strategyUsed: null, hintsUsed: null);
         await _storage.SaveAsync(stat);
-        var loaded = await _storage.LoadRecentAsync(10);
+        IList<QueryExecutionStatistics> loaded = await _storage.LoadRecentAsync(10);
 
         Assert.Single(loaded);
         Assert.Null(loaded[0].StrategyUsed);
@@ -89,7 +89,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
                 timestamp: DateTime.UtcNow.AddMinutes(-i)));
         }
 
-        var loaded = await _storage.LoadRecentAsync(3);
+        IList<QueryExecutionStatistics> loaded = await _storage.LoadRecentAsync(3);
 
         Assert.Equal(3, loaded.Count);
         // Most recent first
@@ -106,7 +106,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
             queryHash: "target",
             timestamp: DateTime.UtcNow.AddDays(-10))); // outside window
 
-        var results = await _storage.GetByQueryHashAsync("target", TimeSpan.FromHours(1));
+        IList<QueryExecutionStatistics> results = await _storage.GetByQueryHashAsync("target", TimeSpan.FromHours(1));
 
         Assert.Single(results);
         Assert.Equal("target", results[0].QueryHash);
@@ -124,12 +124,12 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
         await _storage.SaveAsync(TestStatisticsFactory.Create(
             queryHash: "recent", timestamp: DateTime.UtcNow));
 
-        var allBefore = await _storage.LoadRecentAsync(100);
+        IList<QueryExecutionStatistics> allBefore = await _storage.LoadRecentAsync(100);
         Assert.Equal(2, allBefore.Count);
 
         await _storage.ClearOldAsync(TimeSpan.FromDays(1));
 
-        var allAfter = await _storage.LoadRecentAsync(100);
+        IList<QueryExecutionStatistics> allAfter = await _storage.LoadRecentAsync(100);
         Assert.Single(allAfter);
         Assert.Equal("recent", allAfter[0].QueryHash);
     }
@@ -148,7 +148,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
     public async Task BatchFlushing_DataPersistsCorrectly()
     {
         string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-batch-{Guid.NewGuid()}.db");
-        using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 5, flushIntervalSeconds: 300);
+        using SqliteStatisticsStorage storage = new SqliteStatisticsStorage(dbPath, batchSize: 5, flushIntervalSeconds: 300);
 
         for (int i = 0; i < 5; i++)
             await storage.SaveAsync(TestStatisticsFactory.Create(queryHash: $"batch-{i}"));
@@ -156,7 +156,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
         // Allow fire-and-forget flush triggered at batchSize threshold
         await Task.Delay(500);
 
-        var loaded = await storage.LoadRecentAsync(100);
+        IList<QueryExecutionStatistics> loaded = await storage.LoadRecentAsync(100);
         Assert.Equal(5, loaded.Count);
 
         storage.Dispose();
@@ -167,7 +167,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
     public async Task TimerFlush_PersistsDataBelowBatchThreshold()
     {
         string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-timer-{Guid.NewGuid()}.db");
-        using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 100, flushIntervalSeconds: 1);
+        using SqliteStatisticsStorage storage = new SqliteStatisticsStorage(dbPath, batchSize: 100, flushIntervalSeconds: 1);
 
         // Save below batch threshold
         for (int i = 0; i < 3; i++)
@@ -176,7 +176,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
         // Wait for timer-based flush (1 second interval)
         await Task.Delay(2000);
 
-        var loaded = await storage.LoadRecentAsync(100);
+        IList<QueryExecutionStatistics> loaded = await storage.LoadRecentAsync(100);
         Assert.Equal(3, loaded.Count);
 
         storage.Dispose();
@@ -192,7 +192,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
     {
         string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-dispose-{Guid.NewGuid()}.db");
         // Large batch + long interval so items stay queued until Dispose
-        var storage = new SqliteStatisticsStorage(dbPath, batchSize: 100, flushIntervalSeconds: 300);
+        SqliteStatisticsStorage storage = new SqliteStatisticsStorage(dbPath, batchSize: 100, flushIntervalSeconds: 300);
 
         for (int i = 0; i < 5; i++)
             await storage.SaveAsync(TestStatisticsFactory.Create(queryHash: $"dispose-{i}"));
@@ -200,8 +200,8 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
         storage.Dispose();
 
         // Re-open and verify data was flushed during Dispose
-        using var storage2 = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
-        var loaded = await storage2.LoadRecentAsync(100);
+        using SqliteStatisticsStorage storage2 = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
+        IList<QueryExecutionStatistics> loaded = await storage2.LoadRecentAsync(100);
         Assert.Equal(5, loaded.Count);
 
         storage2.Dispose();
@@ -212,7 +212,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
     public void DoubleDispose_DoesNotThrow()
     {
         string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-dd-{Guid.NewGuid()}.db");
-        var storage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
+        SqliteStatisticsStorage storage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
         storage.Dispose();
         storage.Dispose(); // should not throw
         TryDeleteFiles(dbPath);
@@ -222,7 +222,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
     public async Task SaveAsync_AfterDispose_IsNoOp()
     {
         string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-noop-{Guid.NewGuid()}.db");
-        var storage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
+        SqliteStatisticsStorage storage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
         storage.Dispose();
 
         await storage.SaveAsync(TestStatisticsFactory.Create()); // should not throw
@@ -237,7 +237,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
     public void CustomPath_IsAllowed()
     {
         string customPath = Path.Combine(AppContext.BaseDirectory, "custom-dir", $"universe-test-{Guid.NewGuid()}.db");
-        using var storage = new SqliteStatisticsStorage(customPath, batchSize: 1, flushIntervalSeconds: 60);
+        using SqliteStatisticsStorage storage = new SqliteStatisticsStorage(customPath, batchSize: 1, flushIntervalSeconds: 60);
         storage.Dispose();
         TryDeleteFiles(customPath);
         try
@@ -318,9 +318,9 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
     public async Task ConcurrentSaves_AllRecordsPersisted()
     {
         string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-conc-{Guid.NewGuid()}.db");
-        using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 5, flushIntervalSeconds: 1);
+        using SqliteStatisticsStorage storage = new SqliteStatisticsStorage(dbPath, batchSize: 5, flushIntervalSeconds: 1);
 
-        var tasks = Enumerable.Range(0, 10).Select(taskId =>
+        IEnumerable<Task> tasks = Enumerable.Range(0, 10).Select(taskId =>
             Task.Run(async () =>
             {
                 for (int i = 0; i < 10; i++)
@@ -332,7 +332,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
 
         await Task.WhenAll(tasks);
 
-        var loaded = await storage.LoadRecentAsync(200);
+        IList<QueryExecutionStatistics> loaded = await storage.LoadRecentAsync(200);
         Assert.Equal(100, loaded.Count);
 
         storage.Dispose();
@@ -343,17 +343,17 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
     public async Task ConcurrentSaveAndLoad_CompletesWithoutDeadlock()
     {
         string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-dl-{Guid.NewGuid()}.db");
-        using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 2, flushIntervalSeconds: 1);
+        using SqliteStatisticsStorage storage = new SqliteStatisticsStorage(dbPath, batchSize: 2, flushIntervalSeconds: 1);
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
-        var saveTask = Task.Run(async () =>
+        Task saveTask = Task.Run(async () =>
         {
             for (int i = 0; i < 50 && !cts.IsCancellationRequested; i++)
                 await storage.SaveAsync(TestStatisticsFactory.Create(queryHash: $"dl-{i}"));
         });
 
-        var loadTask = Task.Run(async () =>
+        Task loadTask = Task.Run(async () =>
         {
             for (int i = 0; i < 10 && !cts.IsCancellationRequested; i++)
             {

--- a/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
@@ -16,15 +16,15 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
     public void GetRecommendations_EmptyQueueVsLoadedQueue_ShowsOverhead()
     {
         // Baseline: empty queue
-        using var emptyTuner = new QueryTuner();
-        var sw = Stopwatch.StartNew();
+        using QueryTuner emptyTuner = new QueryTuner();
+        Stopwatch sw = Stopwatch.StartNew();
         for (int i = 0; i < 1000; i++)
             emptyTuner.GetRecommendations(QueryType.Simple);
         sw.Stop();
-        var emptyTime = sw.Elapsed;
+        TimeSpan emptyTime = sw.Elapsed;
 
         // Loaded: 1000-item queue
-        using var loadedTuner = new QueryTuner();
+        using QueryTuner loadedTuner = new QueryTuner();
         for (int i = 0; i < 1000; i++)
             loadedTuner.RecordExecution(TestStatisticsFactory.Create(
                 type: QueryType.Simple,
@@ -34,7 +34,7 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
         for (int i = 0; i < 1000; i++)
             loadedTuner.GetRecommendations(QueryType.Simple);
         sw.Stop();
-        var loadedTime = sw.Elapsed;
+        TimeSpan loadedTime = sw.Elapsed;
 
         _output.WriteLine($"Empty queue: {emptyTime.TotalMilliseconds:F2}ms for 1000 calls");
         _output.WriteLine($"Loaded queue (1000 items): {loadedTime.TotalMilliseconds:F2}ms for 1000 calls");
@@ -52,9 +52,9 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
     public void GetRecommendations_LinearScaling_TimingsIncreaseWithQueueSize()
     {
         int[] sizes = [0, 100, 250, 500, 750, 1000];
-        var timings = new Dictionary<int, double>();
+        Dictionary<int, double> timings = new Dictionary<int, double>();
 
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
         int currentSize = 0;
 
         foreach (int targetSize in sizes)
@@ -67,7 +67,7 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
                 currentSize++;
             }
 
-            var sw = Stopwatch.StartNew();
+            Stopwatch sw = Stopwatch.StartNew();
             for (int i = 0; i < 100; i++)
                 tuner.GetRecommendations(QueryType.Simple);
             sw.Stop();
@@ -86,13 +86,13 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
     [Trait("Category", "Performance")]
     public void GetRecommendations_CumulativeOverhead_WithFullQueue()
     {
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
         for (int i = 0; i < 1000; i++)
             tuner.RecordExecution(TestStatisticsFactory.Create(
                 type: QueryType.Simple,
                 timestamp: DateTime.UtcNow));
 
-        var sw = Stopwatch.StartNew();
+        Stopwatch sw = Stopwatch.StartNew();
         for (int i = 0; i < 1000; i++)
             tuner.GetRecommendations(QueryType.Simple);
         sw.Stop();
@@ -106,7 +106,7 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
     [Trait("Category", "Performance")]
     public void GetRecommendations_MixedTypes_UnrelatedTypeIsNotAffected()
     {
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
 
         // Load 950 Simple entries and 50 Aggregation entries
         for (int i = 0; i < 950; i++)
@@ -119,18 +119,18 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
                 timestamp: DateTime.UtcNow));
 
         // Measure 1000 calls for Simple (950-item partition)
-        var sw = Stopwatch.StartNew();
+        Stopwatch sw = Stopwatch.StartNew();
         for (int i = 0; i < 1000; i++)
             tuner.GetRecommendations(QueryType.Simple);
         sw.Stop();
-        var simpleTime = sw.Elapsed;
+        TimeSpan simpleTime = sw.Elapsed;
 
         // Measure 1000 calls for Aggregation (50-item partition)
         sw.Restart();
         for (int i = 0; i < 1000; i++)
             tuner.GetRecommendations(QueryType.Aggregation);
         sw.Stop();
-        var aggTime = sw.Elapsed;
+        TimeSpan aggTime = sw.Elapsed;
 
         _output.WriteLine($"Simple (950 items): {simpleTime.TotalMilliseconds:F2}ms for 1000 calls");
         _output.WriteLine($"Aggregation (50 items): {aggTime.TotalMilliseconds:F2}ms for 1000 calls");
@@ -147,10 +147,10 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
     [Trait("Category", "Performance")]
     public void ComputeQueryHash_10000Calls_Performance()
     {
-        var context = new QueryContext(QueryType.Simple);
+        QueryContext context = new QueryContext(QueryType.Simple);
         string queryText = "SELECT * FROM c WHERE c.id = @p1 AND c.name = @p2 AND c.status = @p3";
 
-        var sw = Stopwatch.StartNew();
+        Stopwatch sw = Stopwatch.StartNew();
         for (int i = 0; i < 10000; i++)
             QueryTuner.ComputeQueryHash(context, queryText);
         sw.Stop();
@@ -165,10 +165,10 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
     {
         string dbPath = Path.Combine(AppContext.BaseDirectory, $"perf-record-{Guid.NewGuid()}.db");
 
-        using (var storage = new SqliteStatisticsStorage(dbPath, batchSize: 10, flushIntervalSeconds: 60))
-        using (var tuner = new QueryTuner(storage))
+        using (SqliteStatisticsStorage storage = new SqliteStatisticsStorage(dbPath, batchSize: 10, flushIntervalSeconds: 60))
+        using (QueryTuner tuner = new QueryTuner(storage))
         {
-            var sw = Stopwatch.StartNew();
+            Stopwatch sw = Stopwatch.StartNew();
             for (int i = 0; i < 100; i++)
                 tuner.RecordExecution(TestStatisticsFactory.Create(queryHash: $"perf-{i}"));
             sw.Stop();
@@ -191,7 +191,7 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
         string dbPath = Path.Combine(AppContext.BaseDirectory, $"perf-startup-{Guid.NewGuid()}.db");
 
         // Pre-seed SQLite with 1000 records
-        using (var seedStorage = new SqliteStatisticsStorage(dbPath, batchSize: 50, flushIntervalSeconds: 60))
+        using (SqliteStatisticsStorage seedStorage = new SqliteStatisticsStorage(dbPath, batchSize: 50, flushIntervalSeconds: 60))
         {
             for (int i = 0; i < 1000; i++)
                 await seedStorage.SaveAsync(TestStatisticsFactory.Create(
@@ -204,18 +204,18 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
         }
 
         // Measure InMemory startup
-        var sw = Stopwatch.StartNew();
-        using var inMemoryTuner = new QueryTuner();
+        Stopwatch sw = Stopwatch.StartNew();
+        using QueryTuner inMemoryTuner = new QueryTuner();
         await Task.Delay(100); // Give async loading a chance
-        var inMemoryRec = inMemoryTuner.GetRecommendations(QueryType.Simple);
+        QueryTuningRecommendations inMemoryRec = inMemoryTuner.GetRecommendations(QueryType.Simple);
         sw.Stop();
-        var inMemoryTime = sw.Elapsed;
+        TimeSpan inMemoryTime = sw.Elapsed;
 
         // Measure SQLite startup (loading 1000 records into queue)
         QueryTuningRecommendations sqliteRec;
         TimeSpan sqliteTime;
-        using (var sqliteStorage = new SqliteStatisticsStorage(dbPath, batchSize: 50, flushIntervalSeconds: 60))
-        using (var sqliteTuner = new QueryTuner(sqliteStorage))
+        using (SqliteStatisticsStorage sqliteStorage = new SqliteStatisticsStorage(dbPath, batchSize: 50, flushIntervalSeconds: 60))
+        using (QueryTuner sqliteTuner = new QueryTuner(sqliteStorage))
         {
             sw.Restart();
 

--- a/code/Universe.Tests/Tuner/QueryTunerTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerTests.cs
@@ -12,7 +12,7 @@ public sealed class QueryTunerTests
     [Fact]
     public void RecordExecution_CapsAt1000Entries()
     {
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
 
         // Record 200 Aggregation entries first
         for (int i = 0; i < 200; i++)
@@ -25,12 +25,12 @@ public sealed class QueryTunerTests
                 type: QueryType.Simple, queryHash: $"simple-{i}"));
 
         // Aggregation entries should be fully evicted
-        var aggRec = tuner.GetRecommendations(QueryType.Aggregation);
+        QueryTuningRecommendations aggRec = tuner.GetRecommendations(QueryType.Aggregation);
         Assert.False(aggRec.IsDataDriven,
             "Aggregation records should have been evicted by queue cap");
 
         // Simple entries have enough data for data-driven
-        var simpleRec = tuner.GetRecommendations(QueryType.Simple);
+        QueryTuningRecommendations simpleRec = tuner.GetRecommendations(QueryType.Simple);
         Assert.True(simpleRec.IsDataDriven,
             "Simple records should provide data-driven recommendations");
     }
@@ -38,7 +38,7 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRecommendations_OnlyConsidersEntriesOfRequestedType()
     {
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
 
         // Record 200 Simple, 200 Aggregation, 100 VectorSearch
         for (int i = 0; i < 200; i++)
@@ -51,10 +51,10 @@ public sealed class QueryTunerTests
             tuner.RecordExecution(TestStatisticsFactory.Create(
                 type: QueryType.VectorSearch, queryHash: $"vec-{i}"));
 
-        var simpleRec = tuner.GetRecommendations(QueryType.Simple);
-        var aggRec = tuner.GetRecommendations(QueryType.Aggregation);
-        var vecRec = tuner.GetRecommendations(QueryType.VectorSearch);
-        var joinRec = tuner.GetRecommendations(QueryType.Join);
+        QueryTuningRecommendations simpleRec = tuner.GetRecommendations(QueryType.Simple);
+        QueryTuningRecommendations aggRec = tuner.GetRecommendations(QueryType.Aggregation);
+        QueryTuningRecommendations vecRec = tuner.GetRecommendations(QueryType.VectorSearch);
+        QueryTuningRecommendations joinRec = tuner.GetRecommendations(QueryType.Join);
 
         Assert.True(simpleRec.IsDataDriven);
         Assert.Equal(200, simpleRec.SampleSize);
@@ -72,7 +72,7 @@ public sealed class QueryTunerTests
     [Fact]
     public void RecordExecution_GlobalCapAppliesAcrossAllTypes()
     {
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
 
         // Record 500 Simple (oldest), then 500 Aggregation, then 100 VectorSearch
         for (int i = 0; i < 500; i++)
@@ -89,9 +89,9 @@ public sealed class QueryTunerTests
                 timestamp: DateTime.UtcNow.AddMinutes(-i)));
 
         // Total inserted: 1100 → 100 oldest (Simple) should be evicted
-        var simpleRec = tuner.GetRecommendations(QueryType.Simple);
-        var aggRec = tuner.GetRecommendations(QueryType.Aggregation);
-        var vecRec = tuner.GetRecommendations(QueryType.VectorSearch);
+        QueryTuningRecommendations simpleRec = tuner.GetRecommendations(QueryType.Simple);
+        QueryTuningRecommendations aggRec = tuner.GetRecommendations(QueryType.Aggregation);
+        QueryTuningRecommendations vecRec = tuner.GetRecommendations(QueryType.VectorSearch);
 
         // Simple should have lost 100 entries (evicted as oldest)
         Assert.True(simpleRec.IsDataDriven);
@@ -113,11 +113,11 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRecommendations_LessThan10Samples_ReturnsRuleBased()
     {
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
         for (int i = 0; i < 9; i++)
             tuner.RecordExecution(TestStatisticsFactory.Create(type: QueryType.Simple));
 
-        var rec = tuner.GetRecommendations(QueryType.Simple);
+        QueryTuningRecommendations rec = tuner.GetRecommendations(QueryType.Simple);
 
         Assert.False(rec.IsDataDriven);
         Assert.Equal(0, rec.SampleSize);
@@ -126,7 +126,7 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRecommendations_AtLeast10Samples_ReturnsDataDriven()
     {
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
         for (int i = 0; i < 15; i++)
             tuner.RecordExecution(TestStatisticsFactory.Create(
                 type: QueryType.Simple,
@@ -134,7 +134,7 @@ public sealed class QueryTunerTests
                 executionTime: TimeSpan.FromMilliseconds(100 + i * 10),
                 success: i < 12));
 
-        var rec = tuner.GetRecommendations(QueryType.Simple);
+        QueryTuningRecommendations rec = tuner.GetRecommendations(QueryType.Simple);
 
         Assert.True(rec.IsDataDriven);
         Assert.Equal(15, rec.SampleSize);
@@ -150,7 +150,7 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRecommendations_OnlyConsidersLast24Hours()
     {
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
 
         // Add 15 records older than 24 hours
         for (int i = 0; i < 15; i++)
@@ -158,7 +158,7 @@ public sealed class QueryTunerTests
                 type: QueryType.Simple,
                 timestamp: DateTime.UtcNow.AddHours(-25)));
 
-        var rec = tuner.GetRecommendations(QueryType.Simple);
+        QueryTuningRecommendations rec = tuner.GetRecommendations(QueryType.Simple);
         Assert.False(rec.IsDataDriven);
     }
 
@@ -169,13 +169,13 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRecommendations_CorrectAverageRU()
     {
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
         double[] rus = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0];
         for (int i = 0; i < rus.Length; i++)
             tuner.RecordExecution(TestStatisticsFactory.Create(
                 type: QueryType.Simple, ru: rus[i]));
 
-        var rec = tuner.GetRecommendations(QueryType.Simple);
+        QueryTuningRecommendations rec = tuner.GetRecommendations(QueryType.Simple);
 
         Assert.True(rec.IsDataDriven);
         Assert.Equal(55.0, rec.AverageRU);
@@ -184,12 +184,12 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRecommendations_CorrectSuccessRate()
     {
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
         for (int i = 0; i < 10; i++)
             tuner.RecordExecution(TestStatisticsFactory.Create(
                 type: QueryType.Simple, success: i < 7));
 
-        var rec = tuner.GetRecommendations(QueryType.Simple);
+        QueryTuningRecommendations rec = tuner.GetRecommendations(QueryType.Simple);
 
         Assert.True(rec.IsDataDriven);
         Assert.Equal(0.7, rec.SuccessRate);
@@ -198,13 +198,13 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRecommendations_CorrectAverageExecutionTime()
     {
-        using var tuner = new QueryTuner();
+        using QueryTuner tuner = new QueryTuner();
         for (int i = 0; i < 10; i++)
             tuner.RecordExecution(TestStatisticsFactory.Create(
                 type: QueryType.Simple,
                 executionTime: TimeSpan.FromMilliseconds(100 * (i + 1))));
 
-        var rec = tuner.GetRecommendations(QueryType.Simple);
+        QueryTuningRecommendations rec = tuner.GetRecommendations(QueryType.Simple);
 
         Assert.True(rec.IsDataDriven);
         // Average of 100, 200, ..., 1000 = 550ms
@@ -218,8 +218,8 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRuleBasedRecommendations_VectorSearch_HasCorrectHints()
     {
-        using var tuner = new QueryTuner();
-        var rec = tuner.GetRecommendations(QueryType.VectorSearch);
+        using QueryTuner tuner = new QueryTuner();
+        QueryTuningRecommendations rec = tuner.GetRecommendations(QueryType.VectorSearch);
 
         Assert.False(rec.IsDataDriven);
         Assert.NotNull(rec.SuggestedHints);
@@ -230,8 +230,8 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRuleBasedRecommendations_FullTextSearch_HasCorrectHints()
     {
-        using var tuner = new QueryTuner();
-        var rec = tuner.GetRecommendations(QueryType.FullTextSearch);
+        using QueryTuner tuner = new QueryTuner();
+        QueryTuningRecommendations rec = tuner.GetRecommendations(QueryType.FullTextSearch);
 
         Assert.False(rec.IsDataDriven);
         Assert.NotNull(rec.SuggestedHints);
@@ -241,8 +241,8 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRuleBasedRecommendations_Aggregation_HasCorrectHints()
     {
-        using var tuner = new QueryTuner();
-        var rec = tuner.GetRecommendations(QueryType.Aggregation);
+        using QueryTuner tuner = new QueryTuner();
+        QueryTuningRecommendations rec = tuner.GetRecommendations(QueryType.Aggregation);
 
         Assert.False(rec.IsDataDriven);
         Assert.NotNull(rec.SuggestedHints);
@@ -253,8 +253,8 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRuleBasedRecommendations_Complex_HasCorrectHints()
     {
-        using var tuner = new QueryTuner();
-        var rec = tuner.GetRecommendations(QueryType.Complex);
+        using QueryTuner tuner = new QueryTuner();
+        QueryTuningRecommendations rec = tuner.GetRecommendations(QueryType.Complex);
 
         Assert.False(rec.IsDataDriven);
         Assert.NotNull(rec.SuggestedHints);
@@ -265,8 +265,8 @@ public sealed class QueryTunerTests
     [Fact]
     public void GetRuleBasedRecommendations_Simple_EmptyHints()
     {
-        using var tuner = new QueryTuner();
-        var rec = tuner.GetRecommendations(QueryType.Simple);
+        using QueryTuner tuner = new QueryTuner();
+        QueryTuningRecommendations rec = tuner.GetRecommendations(QueryType.Simple);
 
         Assert.False(rec.IsDataDriven);
         Assert.NotNull(rec.SuggestedHints);
@@ -280,7 +280,7 @@ public sealed class QueryTunerTests
     [Fact]
     public void ComputeQueryHash_Deterministic()
     {
-        var context = new QueryContext(QueryType.Simple);
+        QueryContext context = new QueryContext(QueryType.Simple);
         string query = "SELECT * FROM c WHERE c.id = @p1";
 
         string hash1 = QueryTuner.ComputeQueryHash(context, query);
@@ -292,7 +292,7 @@ public sealed class QueryTunerTests
     [Fact]
     public void ComputeQueryHash_NormalizesParameterNames()
     {
-        var context = new QueryContext(QueryType.Simple);
+        QueryContext context = new QueryContext(QueryType.Simple);
         string query1 = "SELECT * FROM c WHERE c.id = @param_abc123";
         string query2 = "SELECT * FROM c WHERE c.id = @param_xyz789";
 
@@ -305,7 +305,7 @@ public sealed class QueryTunerTests
     [Fact]
     public void ComputeQueryHash_DifferentQueries_DifferentHashes()
     {
-        var context = new QueryContext(QueryType.Simple);
+        QueryContext context = new QueryContext(QueryType.Simple);
         string query1 = "SELECT * FROM c WHERE c.id = @p1";
         string query2 = "SELECT * FROM c WHERE c.name = @p1";
 
@@ -318,8 +318,8 @@ public sealed class QueryTunerTests
     [Fact]
     public void ComputeQueryHash_DifferentQueryTypes_DifferentHashes()
     {
-        var context1 = new QueryContext(QueryType.Simple);
-        var context2 = new QueryContext(QueryType.Aggregation);
+        QueryContext context1 = new QueryContext(QueryType.Simple);
+        QueryContext context2 = new QueryContext(QueryType.Aggregation);
         string query = "SELECT * FROM c WHERE c.id = @p1";
 
         string hash1 = QueryTuner.ComputeQueryHash(context1, query);
@@ -338,7 +338,7 @@ public sealed class QueryTunerTests
         string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-startup-{Guid.NewGuid()}.db");
 
         // Pre-seed SQLite with 15 Simple records
-        using (var seedStorage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60))
+        using (SqliteStatisticsStorage seedStorage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60))
         {
             for (int i = 0; i < 15; i++)
                 await seedStorage.SaveAsync(TestStatisticsFactory.Create(
@@ -351,8 +351,8 @@ public sealed class QueryTunerTests
         }
 
         // Create new QueryTuner with fresh SQLite storage
-        using var storage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
-        using var tuner = new QueryTuner(storage);
+        using SqliteStatisticsStorage storage = new SqliteStatisticsStorage(dbPath, batchSize: 1, flushIntervalSeconds: 60);
+        using QueryTuner tuner = new QueryTuner(storage);
 
         // Wait for async loading (poll until data-driven or timeout)
         QueryTuningRecommendations rec = default;
@@ -377,8 +377,8 @@ public sealed class QueryTunerTests
     [Fact]
     public void Dispose_DisposesUnderlyingStorage()
     {
-        var trackable = new TrackingDisposableStorage();
-        var tuner = new QueryTuner(trackable);
+        TrackingDisposableStorage trackable = new TrackingDisposableStorage();
+        QueryTuner tuner = new QueryTuner(trackable);
 
         tuner.Dispose();
 

--- a/code/Universe/Builder/ClusterBuilder.cs
+++ b/code/Universe/Builder/ClusterBuilder.cs
@@ -126,6 +126,6 @@ public sealed class ClusterBuilder
     public ClusterBuilder FTScore(string column, string[] terms, string alias = "c")
         => Catalyst(column, terms, Q.Operator.FTScore, alias);
 
-    internal Options.Cluster Build(Q.Where where)
+    internal Cluster Build(Q.Where where)
         => new(_catalysts, where);
 }

--- a/code/Universe/Builder/ClusterBuilder.cs
+++ b/code/Universe/Builder/ClusterBuilder.cs
@@ -1,0 +1,131 @@
+using Universe.Builder.Options;
+
+namespace Universe.Builder;
+
+/// <summary>
+/// Builder for constructing a single cluster of Catalyst conditions.
+/// Used inside Orbit.Cluster(c => ...) lambdas.
+/// </summary>
+public sealed class ClusterBuilder
+{
+    private readonly List<Catalyst> _catalysts = [];
+    private Q.Where _nextWhere = Q.Where.And;
+
+    /// <summary>Add a filter condition to this cluster.</summary>
+    public ClusterBuilder Catalyst(string column, object value = null,
+        Q.Operator op = Q.Operator.Eq, string alias = "c")
+    {
+        _catalysts.Add(new Catalyst(column, value, _nextWhere, op, alias));
+        _nextWhere = Q.Where.And;
+        return this;
+    }
+
+    /// <summary>The next condition will be joined with AND.</summary>
+    public ClusterBuilder And()
+    {
+        _nextWhere = Q.Where.And;
+        return this;
+    }
+
+    /// <summary>The next condition will be joined with OR.</summary>
+    public ClusterBuilder Or()
+    {
+        _nextWhere = Q.Where.Or;
+        return this;
+    }
+
+    /// <summary>Equality: column = value</summary>
+    public ClusterBuilder Eq(string column, object value, string alias = "c")
+        => Catalyst(column, value, Q.Operator.Eq, alias);
+
+    /// <summary>Inequality: column != value</summary>
+    public ClusterBuilder NotEq(string column, object value, string alias = "c")
+        => Catalyst(column, value, Q.Operator.NotEq, alias);
+
+    /// <summary>Greater than: column > value</summary>
+    public ClusterBuilder Gt(string column, object value, string alias = "c")
+        => Catalyst(column, value, Q.Operator.Gt, alias);
+
+    /// <summary>Greater than or equal: column >= value</summary>
+    public ClusterBuilder Gte(string column, object value, string alias = "c")
+        => Catalyst(column, value, Q.Operator.Gte, alias);
+
+    /// <summary>Less than: column &lt; value</summary>
+    public ClusterBuilder Lt(string column, object value, string alias = "c")
+        => Catalyst(column, value, Q.Operator.Lt, alias);
+
+    /// <summary>Less than or equal: column &lt;= value</summary>
+    public ClusterBuilder Lte(string column, object value, string alias = "c")
+        => Catalyst(column, value, Q.Operator.Lte, alias);
+
+    /// <summary>LIKE pattern matching</summary>
+    public ClusterBuilder Like(string column, string pattern, string alias = "c")
+        => Catalyst(column, pattern, Q.Operator.Like, alias);
+
+    /// <summary>NOT LIKE pattern matching</summary>
+    public ClusterBuilder NotLike(string column, string pattern, string alias = "c")
+        => Catalyst(column, pattern, Q.Operator.NotLike, alias);
+
+    /// <summary>Check if property is defined on the document</summary>
+    public ClusterBuilder Defined(string column, string alias = "c")
+        => Catalyst(column, null, Q.Operator.Defined, alias);
+
+    /// <summary>Check if property is NOT defined on the document</summary>
+    public ClusterBuilder NotDefined(string column, string alias = "c")
+        => Catalyst(column, null, Q.Operator.NotDefined, alias);
+
+    /// <summary>Check if document's array field contains a scalar value</summary>
+    public ClusterBuilder In(string column, object value, string alias = "c")
+        => Catalyst(column, value, Q.Operator.In, alias);
+
+    /// <summary>Check if document's array field does NOT contain a scalar value</summary>
+    public ClusterBuilder NotIn(string column, object value, string alias = "c")
+        => Catalyst(column, value, Q.Operator.NotIn, alias);
+
+    /// <summary>Check if a collection contains the document's scalar field value</summary>
+    public ClusterBuilder Contains(string column, IEnumerable<object> values, string alias = "c")
+        => Catalyst(column, values, Q.Operator.Contains, alias);
+
+    /// <summary>Check if a collection does NOT contain the document's scalar field value</summary>
+    public ClusterBuilder NotContains(string column, IEnumerable<object> values, string alias = "c")
+        => Catalyst(column, values, Q.Operator.NotContains, alias);
+
+    /// <summary>Array length check</summary>
+    public ClusterBuilder Len(string column, int length, string alias = "c")
+        => Catalyst(column, length, Q.Operator.Len, alias);
+
+    /// <summary>Vector distance search</summary>
+    public ClusterBuilder VectorDistance(string column, float[] vector, string alias = "c")
+        => Catalyst(column, vector, Q.Operator.VectorDistance, alias);
+
+    /// <summary>Full-text contains single keyword</summary>
+    public ClusterBuilder FTContains(string column, string keyword, string alias = "c")
+        => Catalyst(column, keyword, Q.Operator.FTContains, alias);
+
+    /// <summary>Negated full-text contains</summary>
+    public ClusterBuilder NotFTContains(string column, string keyword, string alias = "c")
+        => Catalyst(column, keyword, Q.Operator.NotFTContains, alias);
+
+    /// <summary>Full-text contains ALL keywords</summary>
+    public ClusterBuilder FTContainsAll(string column, string[] keywords, string alias = "c")
+        => Catalyst(column, keywords, Q.Operator.FTContainsAll, alias);
+
+    /// <summary>Negated full-text contains all</summary>
+    public ClusterBuilder NotFTContainsAll(string column, string[] keywords, string alias = "c")
+        => Catalyst(column, keywords, Q.Operator.NotFTContainsAll, alias);
+
+    /// <summary>Full-text contains ANY keyword</summary>
+    public ClusterBuilder FTContainsAny(string column, string[] keywords, string alias = "c")
+        => Catalyst(column, keywords, Q.Operator.FTContainsAny, alias);
+
+    /// <summary>Negated full-text contains any</summary>
+    public ClusterBuilder NotFTContainsAny(string column, string[] keywords, string alias = "c")
+        => Catalyst(column, keywords, Q.Operator.NotFTContainsAny, alias);
+
+    /// <summary>Full-text relevance scoring</summary>
+    public ClusterBuilder FTScore(string column, string[] terms, string alias = "c")
+        => Catalyst(column, terms, Q.Operator.FTScore, alias);
+
+    internal Options.Cluster Build(Q.Where where)
+        => new(_catalysts, where);
+}

--- a/code/Universe/Builder/Orbit.cs
+++ b/code/Universe/Builder/Orbit.cs
@@ -152,6 +152,9 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 
     private void ValidateQueryConstraints()
     {
+        if (_galaxy is null)
+            throw new UniverseException("Cannot execute query without a Galaxy instance. Create Orbit via galaxy.Query() extension.");
+
         if (_page.HasValue && _hints.HasValue)
             throw new UniverseException("QueryHints are not supported with paginated queries. Use either Paged() or WithHints(), not both.");
     }
@@ -159,6 +162,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
     /// <summary>Execute the query and return the first matching result.</summary>
     public async Task<(Gravity g, T T)> GetAsync()
     {
+        ValidateQueryConstraints();
         var (clusters, _, _, _) = Build();
         IReadOnlyList<string> columns = _columns.Count > 0 ? _columns : null;
         return await _galaxy.Get(clusters, columns);
@@ -167,6 +171,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
     /// <summary>Execute the query and return the first matching result projected to a different type.</summary>
     public async Task<(Gravity g, TS S)> GetAsync<TS>() where TS : ICosmicEntity
     {
+        ValidateQueryConstraints();
         var (clusters, _, _, _) = Build();
         IReadOnlyList<string> columns = _columns.Count > 0 ? _columns : null;
         return await _galaxy.Get<TS>(clusters, columns);
@@ -175,6 +180,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
     /// <summary>Generate the SQL query without executing it.</summary>
     public Gravity GenerateQuery()
     {
+        ValidateQueryConstraints();
         var (clusters, columnOptions, sorting, groups) = Build();
         return _galaxy.GenerateQuery(clusters, columnOptions, sorting, groups);
     }

--- a/code/Universe/Builder/Orbit.cs
+++ b/code/Universe/Builder/Orbit.cs
@@ -158,6 +158,10 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	}
 
 	/// <summary>Execute the query and return the first matching result.</summary>
+	/// <remarks>
+	/// Only filter conditions (clusters) and column selection (Select) are applied.
+	/// Top, Distinct, Aggregate, GroupBy, and sorting options are ignored. Use ToListAsync for those features.
+	/// </remarks>
 	public async Task<(Gravity g, T T)> GetAsync()
 	{
 		ValidateQueryConstraints();
@@ -167,6 +171,10 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	}
 
 	/// <summary>Execute the query and return the first matching result projected to a different type.</summary>
+	/// <remarks>
+	/// Only filter conditions (clusters) and column selection (Select) are applied.
+	/// Top, Distinct, Aggregate, GroupBy, and sorting options are ignored. Use ToListAsync for those features.
+	/// </remarks>
 	public async Task<(Gravity g, TS S)> GetAsync<TS>() where TS : ICosmicEntity
 	{
 		ValidateQueryConstraints();

--- a/code/Universe/Builder/Orbit.cs
+++ b/code/Universe/Builder/Orbit.cs
@@ -8,209 +8,207 @@ namespace Universe.Builder;
 /// </summary>
 public sealed class Orbit<T> where T : class, ICosmicEntity
 {
-    private readonly IGalaxy<T> _galaxy;
-    private readonly List<(Action<ClusterBuilder> configure, Q.Where where)> _clusterConfigs = [];
-    private readonly List<string> _columns = [];
-    private readonly List<Sorting.Option> _sortingOptions = [];
-    private readonly List<AggregationOption> _aggregates = [];
-    private readonly List<string> _groupByColumns = [];
-    private Q.Page? _page;
-    private int _top;
-    private bool _isDistinct;
-    private JoinOptions _join;
-    private QueryHints? _hints;
-    private Q.Where _nextClusterWhere = Q.Where.And;
+	private readonly IGalaxy<T> _galaxy;
+	private readonly List<(Action<ClusterBuilder> configure, Q.Where where)> _clusterConfigs = [];
+	private readonly List<string> _columns = [];
+	private readonly List<Sorting.Option> _sortingOptions = [];
+	private readonly List<AggregationOption> _aggregates = [];
+	private readonly List<string> _groupByColumns = [];
+	private Q.Page? _page;
+	private int _top;
+	private bool _isDistinct;
+	private JoinOptions _join;
+	private QueryHints? _hints;
+	private Q.Where _nextClusterWhere = Q.Where.And;
 
-    internal Orbit(IGalaxy<T> galaxy)
-    {
-        _galaxy = galaxy;
-    }
+	internal Orbit(IGalaxy<T> galaxy)
+		=> _galaxy = galaxy;
 
-    /// <summary>Add a cluster of filter conditions using a builder lambda.</summary>
-    public Orbit<T> Cluster(Action<ClusterBuilder> configure)
-    {
-        _clusterConfigs.Add((configure, _nextClusterWhere));
-        _nextClusterWhere = Q.Where.And;
-        return this;
-    }
+	/// <summary>Add a cluster of filter conditions using a builder lambda.</summary>
+	public Orbit<T> Cluster(Action<ClusterBuilder> configure)
+	{
+		_clusterConfigs.Add((configure, _nextClusterWhere));
+		_nextClusterWhere = Q.Where.And;
+		return this;
+	}
 
-    /// <summary>The next cluster will be joined with OR.</summary>
-    public Orbit<T> Or()
-    {
-        _nextClusterWhere = Q.Where.Or;
-        return this;
-    }
+	/// <summary>The next cluster will be joined with OR.</summary>
+	public Orbit<T> Or()
+	{
+		_nextClusterWhere = Q.Where.Or;
+		return this;
+	}
 
-    /// <summary>The next cluster will be joined with AND.</summary>
-    public Orbit<T> And()
-    {
-        _nextClusterWhere = Q.Where.And;
-        return this;
-    }
+	/// <summary>The next cluster will be joined with AND.</summary>
+	public Orbit<T> And()
+	{
+		_nextClusterWhere = Q.Where.And;
+		return this;
+	}
 
-    /// <summary>Specify which columns to select.</summary>
-    public Orbit<T> Select(params string[] columns)
-    {
-        _columns.AddRange(columns);
-        return this;
-    }
+	/// <summary>Specify which columns to select.</summary>
+	public Orbit<T> Select(params string[] columns)
+	{
+		_columns.AddRange(columns);
+		return this;
+	}
 
-    /// <summary>Return only distinct results.</summary>
-    public Orbit<T> Distinct()
-    {
-        _isDistinct = true;
-        return this;
-    }
+	/// <summary>Return only distinct results.</summary>
+	public Orbit<T> Distinct()
+	{
+		_isDistinct = true;
+		return this;
+	}
 
-    /// <summary>Limit the number of results returned.</summary>
-    public Orbit<T> Top(int count)
-    {
-        _top = count;
-        return this;
-    }
+	/// <summary>Limit the number of results returned.</summary>
+	public Orbit<T> Top(int count)
+	{
+		_top = count;
+		return this;
+	}
 
-    /// <summary>Add a sort order.</summary>
-    public Orbit<T> OrderBy(string column, Sorting.Direction direction = Sorting.Direction.ASC, string alias = "c")
-    {
-        _sortingOptions.Add(new(column, direction, alias));
-        return this;
-    }
+	/// <summary>Add a sort order.</summary>
+	public Orbit<T> OrderBy(string column, Sorting.Direction direction = Sorting.Direction.ASC, string alias = "c")
+	{
+		_sortingOptions.Add(new(column, direction, alias));
+		return this;
+	}
 
-    /// <summary>Add descending sort order on a column.</summary>
-    public Orbit<T> OrderByDescending(string column, string alias = "c")
-    {
-        _sortingOptions.Add(new(column, Sorting.Direction.DESC, alias));
-        return this;
-    }
+	/// <summary>Add descending sort order on a column.</summary>
+	public Orbit<T> OrderByDescending(string column, string alias = "c")
+	{
+		_sortingOptions.Add(new(column, Sorting.Direction.DESC, alias));
+		return this;
+	}
 
-    /// <summary>Add weighted sorting for RRF ranking.</summary>
-    public Orbit<T> WithWeights(string weights)
-    {
-        _sortingOptions.Add(new(weights, Sorting.Direction.WEIGHTED));
-        return this;
-    }
+	/// <summary>Add weighted sorting for RRF ranking.</summary>
+	public Orbit<T> WithWeights(string weights)
+	{
+		_sortingOptions.Add(new(weights, Sorting.Direction.WEIGHTED));
+		return this;
+	}
 
-    /// <summary>Add an aggregation function.</summary>
-    public Orbit<T> Aggregate(string column, Q.Aggregate aggregate)
-    {
-        _aggregates.Add(new(column, aggregate));
-        return this;
-    }
+	/// <summary>Add an aggregation function.</summary>
+	public Orbit<T> Aggregate(string column, Q.Aggregate aggregate)
+	{
+		_aggregates.Add(new(column, aggregate));
+		return this;
+	}
 
-    /// <summary>Add GROUP BY columns.</summary>
-    public Orbit<T> GroupBy(params string[] columns)
-    {
-        _groupByColumns.AddRange(columns);
-        return this;
-    }
+	/// <summary>Add GROUP BY columns.</summary>
+	public Orbit<T> GroupBy(params string[] columns)
+	{
+		_groupByColumns.AddRange(columns);
+		return this;
+	}
 
-    /// <summary>Enable pagination with specified page size.</summary>
-    public Orbit<T> Paged(int size, string continuationToken = null)
-    {
-        _page = new Q.Page(size, continuationToken);
-        return this;
-    }
+	/// <summary>Enable pagination with specified page size.</summary>
+	public Orbit<T> Paged(int size, string continuationToken = null)
+	{
+		_page = new Q.Page(size, continuationToken);
+		return this;
+	}
 
-    /// <summary>Configure a JOIN on a sub-collection array.</summary>
-    public Orbit<T> Join(string arrayPath, string alias, IReadOnlyList<string> columns = null,
-        IReadOnlyList<AggregationOption> aggregates = null)
-    {
-        _join = new(alias, arrayPath, columns, aggregates);
-        return this;
-    }
+	/// <summary>Configure a JOIN on a sub-collection array.</summary>
+	public Orbit<T> Join(string arrayPath, string alias, IReadOnlyList<string> columns = null,
+		IReadOnlyList<AggregationOption> aggregates = null)
+	{
+		_join = new(alias, arrayPath, columns, aggregates);
+		return this;
+	}
 
-    /// <summary>Provide query optimization hints.</summary>
-    public Orbit<T> WithHints(QueryHints hints)
-    {
-        _hints = hints;
-        return this;
-    }
+	/// <summary>Provide query optimization hints.</summary>
+	public Orbit<T> WithHints(QueryHints hints)
+	{
+		_hints = hints;
+		return this;
+	}
 
-    /// <summary>Execute the query and return a list of results.</summary>
-    public async Task<(Gravity g, IList<T> T)> ToListAsync()
-    {
-        ValidateQueryConstraints();
-        var (clusters, columnOptions, sorting, groups) = Build();
+	/// <summary>Execute the query and return a list of results.</summary>
+	public async Task<(Gravity g, IList<T> T)> ToListAsync()
+	{
+		ValidateQueryConstraints();
+		(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = Build();
 
-        if (_page.HasValue)
-            return await _galaxy.Paged(_page.Value, clusters, columnOptions, sorting, groups);
+		if (_page.HasValue)
+			return await _galaxy.Paged(_page.Value, clusters, columnOptions, sorting, groups);
 
-        return await _galaxy.List(clusters, columnOptions, sorting, groups, _hints);
-    }
+		return await _galaxy.List(clusters, columnOptions, sorting, groups, _hints);
+	}
 
-    /// <summary>Execute the query and return a list of results projected to a different type.</summary>
-    public async Task<(Gravity g, IList<TS> T)> ToListAsync<TS>() where TS : ICosmicEntity
-    {
-        ValidateQueryConstraints();
-        var (clusters, columnOptions, sorting, groups) = Build();
+	/// <summary>Execute the query and return a list of results projected to a different type.</summary>
+	public async Task<(Gravity g, IList<TS> T)> ToListAsync<TS>() where TS : ICosmicEntity
+	{
+		ValidateQueryConstraints();
+		(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = Build();
 
-        if (_page.HasValue)
-            return await _galaxy.Paged<TS>(_page.Value, clusters, columnOptions, sorting, groups);
+		if (_page.HasValue)
+			return await _galaxy.Paged<TS>(_page.Value, clusters, columnOptions, sorting, groups);
 
-        return await _galaxy.List<TS>(clusters, columnOptions, sorting, groups, _hints);
-    }
+		return await _galaxy.List<TS>(clusters, columnOptions, sorting, groups, _hints);
+	}
 
-    private void ValidateQueryConstraints()
-    {
-        if (_galaxy is null)
-            throw new UniverseException("Cannot execute query without a Galaxy instance. Create Orbit via galaxy.Query() extension.");
+	private void ValidateQueryConstraints()
+	{
+		if (_galaxy is null)
+			throw new UniverseException("Cannot execute query without a Galaxy instance. Create Orbit via galaxy.Query() extension.");
 
-        if (_page.HasValue && _hints.HasValue)
-            throw new UniverseException("QueryHints are not supported with paginated queries. Use either Paged() or WithHints(), not both.");
-    }
+		if (_page.HasValue && _hints.HasValue)
+			throw new UniverseException("QueryHints are not supported with paginated queries. Use either Paged() or WithHints(), not both.");
+	}
 
-    /// <summary>Execute the query and return the first matching result.</summary>
-    public async Task<(Gravity g, T T)> GetAsync()
-    {
-        ValidateQueryConstraints();
-        var (clusters, _, _, _) = Build();
-        IReadOnlyList<string> columns = _columns.Count > 0 ? _columns : null;
-        return await _galaxy.Get(clusters, columns);
-    }
+	/// <summary>Execute the query and return the first matching result.</summary>
+	public async Task<(Gravity g, T T)> GetAsync()
+	{
+		ValidateQueryConstraints();
+		(IReadOnlyList<Cluster> clusters, _, _, _) = Build();
+		IReadOnlyList<string> columns = _columns.Count > 0 ? _columns : null;
+		return await _galaxy.Get(clusters, columns);
+	}
 
-    /// <summary>Execute the query and return the first matching result projected to a different type.</summary>
-    public async Task<(Gravity g, TS S)> GetAsync<TS>() where TS : ICosmicEntity
-    {
-        ValidateQueryConstraints();
-        var (clusters, _, _, _) = Build();
-        IReadOnlyList<string> columns = _columns.Count > 0 ? _columns : null;
-        return await _galaxy.Get<TS>(clusters, columns);
-    }
+	/// <summary>Execute the query and return the first matching result projected to a different type.</summary>
+	public async Task<(Gravity g, TS S)> GetAsync<TS>() where TS : ICosmicEntity
+	{
+		ValidateQueryConstraints();
+		(IReadOnlyList<Cluster> clusters, _, _, _) = Build();
+		IReadOnlyList<string> columns = _columns.Count > 0 ? _columns : null;
+		return await _galaxy.Get<TS>(clusters, columns);
+	}
 
-    /// <summary>Generate the SQL query without executing it.</summary>
-    public Gravity GenerateQuery()
-    {
-        ValidateQueryConstraints();
-        var (clusters, columnOptions, sorting, groups) = Build();
-        return _galaxy.GenerateQuery(clusters, columnOptions, sorting, groups);
-    }
+	/// <summary>Generate the SQL query without executing it.</summary>
+	public Gravity GenerateQuery()
+	{
+		ValidateQueryConstraints();
+		(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = Build();
+		return _galaxy.GenerateQuery(clusters, columnOptions, sorting, groups);
+	}
 
-    internal (IReadOnlyList<Options.Cluster> clusters, ColumnOptions? columnOptions,
-        IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) Build()
-    {
-        List<Options.Cluster> clusters = [];
-        foreach (var (configure, where) in _clusterConfigs)
-        {
-            ClusterBuilder cb = new();
-            configure(cb);
-            clusters.Add(cb.Build(where));
-        }
+	internal (IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions,
+		IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) Build()
+	{
+		List<Cluster> clusters = [];
+		foreach ((Action<ClusterBuilder> configure, Q.Where where) in _clusterConfigs)
+		{
+			ClusterBuilder cb = new();
+			configure(cb);
+			clusters.Add(cb.Build(where));
+		}
 
-        ColumnOptions? columnOptions = null;
-        if (_columns.Count > 0 || _top > 0 || _isDistinct || _aggregates.Count > 0 || _join is not null)
-        {
-            columnOptions = new ColumnOptions(
-                Names: _columns.Count > 0 ? _columns : null,
-                IsDistinct: _isDistinct,
-                Top: _top,
-                Aggregates: _aggregates.Count > 0 ? _aggregates : null,
-                Join: _join
-            );
-        }
+		ColumnOptions? columnOptions = null;
+		if (_columns.Count > 0 || _top > 0 || _isDistinct || _aggregates.Count > 0 || _join is not null)
+		{
+			columnOptions = new ColumnOptions(
+				Names: _columns.Count > 0 ? _columns : null,
+				IsDistinct: _isDistinct,
+				Top: _top,
+				Aggregates: _aggregates.Count > 0 ? _aggregates : null,
+				Join: _join
+			);
+		}
 
-        IReadOnlyList<Sorting.Option> sorting = _sortingOptions.Count > 0 ? _sortingOptions : null;
-        IReadOnlyList<string> groups = _groupByColumns.Count > 0 ? _groupByColumns : null;
+		IReadOnlyList<Sorting.Option> sorting = _sortingOptions.Count > 0 ? _sortingOptions : null;
+		IReadOnlyList<string> groups = _groupByColumns.Count > 0 ? _groupByColumns : null;
 
-        return (clusters.Count > 0 ? clusters : null, columnOptions, sorting, groups);
-    }
+		return (clusters.Count > 0 ? clusters : null, columnOptions, sorting, groups);
+	}
 }

--- a/code/Universe/Builder/Orbit.cs
+++ b/code/Universe/Builder/Orbit.cs
@@ -27,6 +27,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	/// <summary>Add a cluster of filter conditions using a builder lambda.</summary>
 	public Orbit<T> Cluster(Action<ClusterBuilder> configure)
 	{
+		ArgumentNullException.ThrowIfNull(configure);
 		_clusterConfigs.Add((configure, _nextClusterWhere));
 		_nextClusterWhere = Q.Where.And;
 		return this;
@@ -49,6 +50,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	/// <summary>Specify which columns to select.</summary>
 	public Orbit<T> Select(params string[] columns)
 	{
+		ArgumentNullException.ThrowIfNull(columns);
 		_columns.AddRange(columns);
 		return this;
 	}
@@ -98,6 +100,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	/// <summary>Add GROUP BY columns.</summary>
 	public Orbit<T> GroupBy(params string[] columns)
 	{
+		ArgumentNullException.ThrowIfNull(columns);
 		_groupByColumns.AddRange(columns);
 		return this;
 	}

--- a/code/Universe/Builder/Orbit.cs
+++ b/code/Universe/Builder/Orbit.cs
@@ -1,0 +1,210 @@
+using Universe.Builder.Options;
+using Universe.Response;
+
+namespace Universe.Builder;
+
+/// <summary>
+/// Fluent query builder for Galaxy queries. Create via galaxy.Query() extension method.
+/// </summary>
+public sealed class Orbit<T> where T : class, ICosmicEntity
+{
+    private readonly IGalaxy<T> _galaxy;
+    private readonly List<(Action<ClusterBuilder> configure, Q.Where where)> _clusterConfigs = [];
+    private readonly List<string> _columns = [];
+    private readonly List<Sorting.Option> _sortingOptions = [];
+    private readonly List<AggregationOption> _aggregates = [];
+    private readonly List<string> _groupByColumns = [];
+    private Q.Page? _page;
+    private int _top;
+    private bool _isDistinct;
+    private JoinOptions _join;
+    private QueryHints? _hints;
+    private Q.Where _nextClusterWhere = Q.Where.And;
+
+    internal Orbit(IGalaxy<T> galaxy)
+    {
+        _galaxy = galaxy;
+    }
+
+    /// <summary>Add a cluster of filter conditions using a builder lambda.</summary>
+    public Orbit<T> Cluster(Action<ClusterBuilder> configure)
+    {
+        _clusterConfigs.Add((configure, _nextClusterWhere));
+        _nextClusterWhere = Q.Where.And;
+        return this;
+    }
+
+    /// <summary>The next cluster will be joined with OR.</summary>
+    public Orbit<T> Or()
+    {
+        _nextClusterWhere = Q.Where.Or;
+        return this;
+    }
+
+    /// <summary>The next cluster will be joined with AND.</summary>
+    public Orbit<T> And()
+    {
+        _nextClusterWhere = Q.Where.And;
+        return this;
+    }
+
+    /// <summary>Specify which columns to select.</summary>
+    public Orbit<T> Select(params string[] columns)
+    {
+        _columns.AddRange(columns);
+        return this;
+    }
+
+    /// <summary>Return only distinct results.</summary>
+    public Orbit<T> Distinct()
+    {
+        _isDistinct = true;
+        return this;
+    }
+
+    /// <summary>Limit the number of results returned.</summary>
+    public Orbit<T> Top(int count)
+    {
+        _top = count;
+        return this;
+    }
+
+    /// <summary>Add a sort order.</summary>
+    public Orbit<T> OrderBy(string column, Sorting.Direction direction = Sorting.Direction.ASC, string alias = "c")
+    {
+        _sortingOptions.Add(new(column, direction, alias));
+        return this;
+    }
+
+    /// <summary>Add descending sort order on a column.</summary>
+    public Orbit<T> OrderByDescending(string column, string alias = "c")
+    {
+        _sortingOptions.Add(new(column, Sorting.Direction.DESC, alias));
+        return this;
+    }
+
+    /// <summary>Add weighted sorting for RRF ranking.</summary>
+    public Orbit<T> WithWeights(string weights)
+    {
+        _sortingOptions.Add(new(weights, Sorting.Direction.WEIGHTED));
+        return this;
+    }
+
+    /// <summary>Add an aggregation function.</summary>
+    public Orbit<T> Aggregate(string column, Q.Aggregate aggregate)
+    {
+        _aggregates.Add(new(column, aggregate));
+        return this;
+    }
+
+    /// <summary>Add GROUP BY columns.</summary>
+    public Orbit<T> GroupBy(params string[] columns)
+    {
+        _groupByColumns.AddRange(columns);
+        return this;
+    }
+
+    /// <summary>Enable pagination with specified page size.</summary>
+    public Orbit<T> Paged(int size, string continuationToken = null)
+    {
+        _page = new Q.Page(size, continuationToken);
+        return this;
+    }
+
+    /// <summary>Configure a JOIN on a sub-collection array.</summary>
+    public Orbit<T> Join(string arrayPath, string alias, IReadOnlyList<string> columns = null,
+        IReadOnlyList<AggregationOption> aggregates = null)
+    {
+        _join = new(alias, arrayPath, columns, aggregates);
+        return this;
+    }
+
+    /// <summary>Provide query optimization hints.</summary>
+    public Orbit<T> WithHints(QueryHints hints)
+    {
+        _hints = hints;
+        return this;
+    }
+
+    /// <summary>Execute the query and return a list of results.</summary>
+    public async Task<(Gravity g, IList<T> T)> ToListAsync()
+    {
+        ValidateQueryConstraints();
+        var (clusters, columnOptions, sorting, groups) = Build();
+
+        if (_page.HasValue)
+            return await _galaxy.Paged(_page.Value, clusters, columnOptions, sorting, groups);
+
+        return await _galaxy.List(clusters, columnOptions, sorting, groups, _hints);
+    }
+
+    /// <summary>Execute the query and return a list of results projected to a different type.</summary>
+    public async Task<(Gravity g, IList<TS> T)> ToListAsync<TS>() where TS : ICosmicEntity
+    {
+        ValidateQueryConstraints();
+        var (clusters, columnOptions, sorting, groups) = Build();
+
+        if (_page.HasValue)
+            return await _galaxy.Paged<TS>(_page.Value, clusters, columnOptions, sorting, groups);
+
+        return await _galaxy.List<TS>(clusters, columnOptions, sorting, groups, _hints);
+    }
+
+    private void ValidateQueryConstraints()
+    {
+        if (_page.HasValue && _hints.HasValue)
+            throw new UniverseException("QueryHints are not supported with paginated queries. Use either Paged() or WithHints(), not both.");
+    }
+
+    /// <summary>Execute the query and return the first matching result.</summary>
+    public async Task<(Gravity g, T T)> GetAsync()
+    {
+        var (clusters, _, _, _) = Build();
+        IReadOnlyList<string> columns = _columns.Count > 0 ? _columns : null;
+        return await _galaxy.Get(clusters, columns);
+    }
+
+    /// <summary>Execute the query and return the first matching result projected to a different type.</summary>
+    public async Task<(Gravity g, TS S)> GetAsync<TS>() where TS : ICosmicEntity
+    {
+        var (clusters, _, _, _) = Build();
+        IReadOnlyList<string> columns = _columns.Count > 0 ? _columns : null;
+        return await _galaxy.Get<TS>(clusters, columns);
+    }
+
+    /// <summary>Generate the SQL query without executing it.</summary>
+    public Gravity GenerateQuery()
+    {
+        var (clusters, columnOptions, sorting, groups) = Build();
+        return _galaxy.GenerateQuery(clusters, columnOptions, sorting, groups);
+    }
+
+    internal (IReadOnlyList<Options.Cluster> clusters, ColumnOptions? columnOptions,
+        IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) Build()
+    {
+        List<Options.Cluster> clusters = [];
+        foreach (var (configure, where) in _clusterConfigs)
+        {
+            ClusterBuilder cb = new();
+            configure(cb);
+            clusters.Add(cb.Build(where));
+        }
+
+        ColumnOptions? columnOptions = null;
+        if (_columns.Count > 0 || _top > 0 || _isDistinct || _aggregates.Count > 0 || _join is not null)
+        {
+            columnOptions = new ColumnOptions(
+                Names: _columns.Count > 0 ? _columns : null,
+                IsDistinct: _isDistinct,
+                Top: _top,
+                Aggregates: _aggregates.Count > 0 ? _aggregates : null,
+                Join: _join
+            );
+        }
+
+        IReadOnlyList<Sorting.Option> sorting = _sortingOptions.Count > 0 ? _sortingOptions : null;
+        IReadOnlyList<string> groups = _groupByColumns.Count > 0 ? _groupByColumns : null;
+
+        return (clusters.Count > 0 ? clusters : null, columnOptions, sorting, groups);
+    }
+}

--- a/code/Universe/Builder/Orbit.cs
+++ b/code/Universe/Builder/Orbit.cs
@@ -65,6 +65,8 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	/// <summary>Limit the number of results returned.</summary>
 	public Orbit<T> Top(int count)
 	{
+		if (count < 0)
+			throw new UniverseException("Top count must be a non-negative value.");
 		_top = count;
 		return this;
 	}
@@ -163,7 +165,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	/// <summary>Execute the query and return the first matching result.</summary>
 	/// <remarks>
 	/// Only filter conditions (clusters) and column selection (Select) are applied.
-	/// Top, Distinct, Aggregate, GroupBy, and sorting options are ignored. Use ToListAsync for those features.
+	/// Top, Distinct, Aggregate, GroupBy, sorting, Join, Paged, and WithHints options are ignored. Use ToListAsync for those features.
 	/// </remarks>
 	public async Task<(Gravity g, T T)> GetAsync()
 	{
@@ -176,7 +178,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	/// <summary>Execute the query and return the first matching result projected to a different type.</summary>
 	/// <remarks>
 	/// Only filter conditions (clusters) and column selection (Select) are applied.
-	/// Top, Distinct, Aggregate, GroupBy, and sorting options are ignored. Use ToListAsync for those features.
+	/// Top, Distinct, Aggregate, GroupBy, sorting, Join, Paged, and WithHints options are ignored. Use ToListAsync for those features.
 	/// </remarks>
 	public async Task<(Gravity g, TS S)> GetAsync<TS>() where TS : ICosmicEntity
 	{

--- a/code/Universe/Builder/Strategies/QueryTuner.cs
+++ b/code/Universe/Builder/Strategies/QueryTuner.cs
@@ -61,7 +61,7 @@ internal sealed partial class QueryTuner : IDisposable
     private int CountActual()
     {
         int count = 0;
-        foreach (var kvp in _partitions)
+        foreach (KeyValuePair<QueryType, ConcurrentQueue<QueryExecutionStatistics>> kvp in _partitions)
             count += kvp.Value.Count;
         return count;
     }
@@ -71,9 +71,9 @@ internal sealed partial class QueryTuner : IDisposable
         QueryType? oldestType = null;
         DateTime oldestTimestamp = DateTime.MaxValue;
 
-        foreach (var kvp in _partitions)
+        foreach (KeyValuePair<QueryType, ConcurrentQueue<QueryExecutionStatistics>> kvp in _partitions)
         {
-            if (kvp.Value.TryPeek(out var front) && front.Timestamp < oldestTimestamp)
+            if (kvp.Value.TryPeek(out QueryExecutionStatistics front) && front.Timestamp < oldestTimestamp)
             {
                 oldestTimestamp = front.Timestamp;
                 oldestType = kvp.Key;
@@ -180,7 +180,7 @@ internal sealed partial class QueryTuner : IDisposable
         if (hintPerformance != null)
         {
             Dictionary<string, object> hints = [];
-            foreach (var hint in hintPerformance.Hints)
+            foreach (KeyValuePair<string, object> hint in hintPerformance.Hints)
             {
                 hints[hint.Key] = hint.Value;
             }
@@ -217,7 +217,7 @@ internal sealed partial class QueryTuner : IDisposable
     /// </summary>
     private static string GetHintsSignature(IReadOnlyDictionary<string, object> hints)
     {
-        var sorted = hints.OrderBy(kvp => kvp.Key);
+        IOrderedEnumerable<KeyValuePair<string, object>> sorted = hints.OrderBy(kvp => kvp.Key);
         return string.Join("|", sorted.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
     }
 

--- a/code/Universe/Extensions/OrbitExtensions.cs
+++ b/code/Universe/Extensions/OrbitExtensions.cs
@@ -9,5 +9,5 @@ public static class OrbitExtensions
 {
     /// <summary>Create a fluent query builder for this Galaxy repository.</summary>
     public static Orbit<T> Query<T>(this IGalaxy<T> galaxy) where T : class, ICosmicEntity
-        => new(galaxy);
+        => new(galaxy ?? throw new UniverseException("Cannot create query builder without a Galaxy instance."));
 }

--- a/code/Universe/Extensions/OrbitExtensions.cs
+++ b/code/Universe/Extensions/OrbitExtensions.cs
@@ -1,0 +1,13 @@
+using Universe.Builder;
+
+namespace Universe.Extensions;
+
+/// <summary>
+/// Extension methods for creating fluent query builders on Galaxy instances.
+/// </summary>
+public static class OrbitExtensions
+{
+    /// <summary>Create a fluent query builder for this Galaxy repository.</summary>
+    public static Orbit<T> Query<T>(this IGalaxy<T> galaxy) where T : class, ICosmicEntity
+        => new(galaxy);
+}

--- a/code/Universe/UniverseQuery.csproj
+++ b/code/Universe/UniverseQuery.csproj
@@ -21,13 +21,13 @@
 		<RepositoryType>Git</RepositoryType>
 		<Authors>norarrsgd</Authors>
 		<Product>Universe</Product>
-		<Version>3.2.0</Version>
+		<Version>3.3.0-preview.1</Version>
 		<PackageReleaseNotes>
 			View release on
 			https://github.com/norarrsgd/universe/releases/tag/untagged-cdcf4202c2656450c07b
 		</PackageReleaseNotes>
-		<AssemblyVersion>3.2.0.0</AssemblyVersion>
-		<FileVersion>3.2.0.0</FileVersion>
+		<AssemblyVersion>3.3.0.0</AssemblyVersion>
+		<FileVersion>3.3.0.0</FileVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -545,9 +545,17 @@
         </member>
         <member name="M:Universe.Builder.Orbit`1.GetAsync">
             <summary>Execute the query and return the first matching result.</summary>
+            <remarks>
+            Only filter conditions (clusters) and column selection (Select) are applied.
+            Top, Distinct, Aggregate, GroupBy, and sorting options are ignored. Use ToListAsync for those features.
+            </remarks>
         </member>
         <member name="M:Universe.Builder.Orbit`1.GetAsync``1">
             <summary>Execute the query and return the first matching result projected to a different type.</summary>
+            <remarks>
+            Only filter conditions (clusters) and column selection (Select) are applied.
+            Top, Distinct, Aggregate, GroupBy, and sorting options are ignored. Use ToListAsync for those features.
+            </remarks>
         </member>
         <member name="M:Universe.Builder.Orbit`1.GenerateQuery">
             <summary>Generate the SQL query without executing it.</summary>

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -31,6 +31,90 @@
             <param name="sequence">The partition key sequence number (1-3).</param>
             <param name="keyName">The name of the partition key.</param>
         </member>
+        <member name="T:Universe.Builder.ClusterBuilder">
+            <summary>
+            Builder for constructing a single cluster of Catalyst conditions.
+            Used inside Orbit.Cluster(c => ...) lambdas.
+            </summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.Catalyst(System.String,System.Object,Universe.Builder.Options.Q.Operator,System.String)">
+            <summary>Add a filter condition to this cluster.</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.And">
+            <summary>The next condition will be joined with AND.</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.Or">
+            <summary>The next condition will be joined with OR.</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.Eq(System.String,System.Object,System.String)">
+            <summary>Equality: column = value</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.NotEq(System.String,System.Object,System.String)">
+            <summary>Inequality: column != value</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.Gt(System.String,System.Object,System.String)">
+            <summary>Greater than: column > value</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.Gte(System.String,System.Object,System.String)">
+            <summary>Greater than or equal: column >= value</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.Lt(System.String,System.Object,System.String)">
+            <summary>Less than: column &lt; value</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.Lte(System.String,System.Object,System.String)">
+            <summary>Less than or equal: column &lt;= value</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.Like(System.String,System.String,System.String)">
+            <summary>LIKE pattern matching</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.NotLike(System.String,System.String,System.String)">
+            <summary>NOT LIKE pattern matching</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.Defined(System.String,System.String)">
+            <summary>Check if property is defined on the document</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.NotDefined(System.String,System.String)">
+            <summary>Check if property is NOT defined on the document</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.In(System.String,System.Object,System.String)">
+            <summary>Check if document's array field contains a scalar value</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.NotIn(System.String,System.Object,System.String)">
+            <summary>Check if document's array field does NOT contain a scalar value</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.Contains(System.String,System.Collections.Generic.IEnumerable{System.Object},System.String)">
+            <summary>Check if a collection contains the document's scalar field value</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.NotContains(System.String,System.Collections.Generic.IEnumerable{System.Object},System.String)">
+            <summary>Check if a collection does NOT contain the document's scalar field value</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.Len(System.String,System.Int32,System.String)">
+            <summary>Array length check</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.VectorDistance(System.String,System.Single[],System.String)">
+            <summary>Vector distance search</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.FTContains(System.String,System.String,System.String)">
+            <summary>Full-text contains single keyword</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.NotFTContains(System.String,System.String,System.String)">
+            <summary>Negated full-text contains</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.FTContainsAll(System.String,System.String[],System.String)">
+            <summary>Full-text contains ALL keywords</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.NotFTContainsAll(System.String,System.String[],System.String)">
+            <summary>Negated full-text contains all</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.FTContainsAny(System.String,System.String[],System.String)">
+            <summary>Full-text contains ANY keyword</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.NotFTContainsAny(System.String,System.String[],System.String)">
+            <summary>Negated full-text contains any</summary>
+        </member>
+        <member name="M:Universe.Builder.ClusterBuilder.FTScore(System.String,System.String[],System.String)">
+            <summary>Full-text relevance scoring</summary>
+        </member>
         <member name="T:Universe.Builder.Options.AggregationOption">
             <summary>
             Represents a column aggregation.
@@ -405,6 +489,68 @@
         </member>
         <member name="P:Universe.Builder.Options.Cluster.Where">
             <summary>Where operator (eg AND / OR)</summary>
+        </member>
+        <member name="T:Universe.Builder.Orbit`1">
+            <summary>
+            Fluent query builder for Galaxy queries. Create via galaxy.Query() extension method.
+            </summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.Cluster(System.Action{Universe.Builder.ClusterBuilder})">
+            <summary>Add a cluster of filter conditions using a builder lambda.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.Or">
+            <summary>The next cluster will be joined with OR.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.And">
+            <summary>The next cluster will be joined with AND.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.Select(System.String[])">
+            <summary>Specify which columns to select.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.Distinct">
+            <summary>Return only distinct results.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.Top(System.Int32)">
+            <summary>Limit the number of results returned.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.OrderBy(System.String,Universe.Builder.Options.Sorting.Direction,System.String)">
+            <summary>Add a sort order.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.OrderByDescending(System.String,System.String)">
+            <summary>Add descending sort order on a column.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.WithWeights(System.String)">
+            <summary>Add weighted sorting for RRF ranking.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.Aggregate(System.String,Universe.Builder.Options.Q.Aggregate)">
+            <summary>Add an aggregation function.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.GroupBy(System.String[])">
+            <summary>Add GROUP BY columns.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.Paged(System.Int32,System.String)">
+            <summary>Enable pagination with specified page size.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.Join(System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Collections.Generic.IReadOnlyList{Universe.Builder.Options.AggregationOption})">
+            <summary>Configure a JOIN on a sub-collection array.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.WithHints(Universe.Builder.Options.QueryHints)">
+            <summary>Provide query optimization hints.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.ToListAsync">
+            <summary>Execute the query and return a list of results.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.ToListAsync``1">
+            <summary>Execute the query and return a list of results projected to a different type.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.GetAsync">
+            <summary>Execute the query and return the first matching result.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.GetAsync``1">
+            <summary>Execute the query and return the first matching result projected to a different type.</summary>
+        </member>
+        <member name="M:Universe.Builder.Orbit`1.GenerateQuery">
+            <summary>Generate the SQL query without executing it.</summary>
         </member>
         <member name="T:Universe.Builder.Strategies.DirectQueryStrategy">
             <summary>
@@ -840,6 +986,14 @@
             <summary>
             Converts an object to bool, handling both JsonElement (from deserialized JSON) and primitive types
             </summary>
+        </member>
+        <member name="T:Universe.Extensions.OrbitExtensions">
+            <summary>
+            Extension methods for creating fluent query builders on Galaxy instances.
+            </summary>
+        </member>
+        <member name="M:Universe.Extensions.OrbitExtensions.Query``1(Universe.Interfaces.IGalaxy{``0})">
+            <summary>Create a fluent query builder for this Galaxy repository.</summary>
         </member>
         <member name="T:Universe.Extensions.CosmicEntityExtensions">
             <summary> Extensions for ICosmicEntity </summary>

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -547,14 +547,14 @@
             <summary>Execute the query and return the first matching result.</summary>
             <remarks>
             Only filter conditions (clusters) and column selection (Select) are applied.
-            Top, Distinct, Aggregate, GroupBy, and sorting options are ignored. Use ToListAsync for those features.
+            Top, Distinct, Aggregate, GroupBy, sorting, Join, Paged, and WithHints options are ignored. Use ToListAsync for those features.
             </remarks>
         </member>
         <member name="M:Universe.Builder.Orbit`1.GetAsync``1">
             <summary>Execute the query and return the first matching result projected to a different type.</summary>
             <remarks>
             Only filter conditions (clusters) and column selection (Select) are applied.
-            Top, Distinct, Aggregate, GroupBy, and sorting options are ignored. Use ToListAsync for those features.
+            Top, Distinct, Aggregate, GroupBy, sorting, Join, Paged, and WithHints options are ignored. Use ToListAsync for those features.
             </remarks>
         </member>
         <member name="M:Universe.Builder.Orbit`1.GenerateQuery">

--- a/docs/FLUENT_QUERY_BUILDER.md
+++ b/docs/FLUENT_QUERY_BUILDER.md
@@ -1,0 +1,500 @@
+# Fluent Query Builder (Orbit)
+
+The `Orbit<T>` fluent query builder provides a chainable, readable alternative to the declarative `Cluster`/`Catalyst` array syntax. Both approaches produce identical Cosmos DB queries — `Orbit` is purely a construction layer that delegates to the existing `IGalaxy<T>` methods.
+
+## Quick Start
+
+```csharp
+using Universe.Extensions; // Provides the .Query() extension method
+
+// Fluent
+var (g, results) = await galaxy.Query()
+    .Select("id", "name", "price")
+    .Top(20)
+    .Cluster(c => c.Like("name", "%Test%").And().Lte("price", 50.0))
+    .Or()
+    .Cluster(c => c.Eq("code", "SPECIAL"))
+    .OrderByDescending("price")
+    .ToListAsync();
+```
+
+This is equivalent to the declarative approach:
+
+```csharp
+var (g, results) = await galaxy.List(
+    clusters:
+    [
+        new(Catalysts:
+        [
+            new("name", "%Test%", Operator: Q.Operator.Like),
+            new("price", 50.0, Operator: Q.Operator.Lte, Where: Q.Where.And)
+        ], Where: Q.Where.And),
+        new(Catalysts:
+        [
+            new("code", "SPECIAL")
+        ], Where: Q.Where.Or)
+    ],
+    columnOptions: new(Names: ["id", "name", "price"], Top: 20),
+    sorting: [new("price", Sorting.Direction.DESC)]
+);
+```
+
+## Entry Point
+
+Call `.Query()` on any `IGalaxy<T>` instance to start building a fluent query:
+
+```csharp
+IGalaxy<MyModel> galaxy = ...; // injected via DI
+
+var orbit = galaxy.Query(); // returns Orbit<MyModel>
+```
+
+The `Query()` extension method is defined in the `Universe.Extensions` namespace, which is automatically available within the Universe library via global usings.
+
+## Building Queries
+
+### Clusters and Catalysts
+
+Clusters group filter conditions. Use the `.Cluster()` method with a lambda that receives a `ClusterBuilder`:
+
+```csharp
+// Single cluster with one condition
+galaxy.Query()
+    .Cluster(c => c.Eq("status", "active"))
+    .ToListAsync();
+
+// Single cluster with multiple AND conditions
+galaxy.Query()
+    .Cluster(c => c
+        .Eq("status", "active")
+        .And().Gte("price", 10.0)
+        .And().Lte("price", 100.0))
+    .ToListAsync();
+
+// Single cluster with OR conditions
+galaxy.Query()
+    .Cluster(c => c
+        .Eq("category", "Electronics")
+        .Or().Eq("category", "Books"))
+    .ToListAsync();
+```
+
+### Combining Multiple Clusters
+
+Use `.And()` or `.Or()` between `.Cluster()` calls to control how clusters are combined:
+
+```csharp
+// (status = "active" AND price >= 10) AND (category = "Electronics")
+galaxy.Query()
+    .Cluster(c => c.Eq("status", "active").And().Gte("price", 10.0))
+    .And()
+    .Cluster(c => c.Eq("category", "Electronics"))
+    .ToListAsync();
+
+// (status = "active") OR (featured IS_DEFINED)
+galaxy.Query()
+    .Cluster(c => c.Eq("status", "active"))
+    .Or()
+    .Cluster(c => c.Defined("featured"))
+    .ToListAsync();
+```
+
+If no `.And()` or `.Or()` is called between clusters, `.And()` is used by default:
+
+```csharp
+// These are equivalent:
+galaxy.Query()
+    .Cluster(c => c.Eq("a", 1))
+    .Cluster(c => c.Eq("b", 2))  // implicitly AND
+    .ToListAsync();
+
+galaxy.Query()
+    .Cluster(c => c.Eq("a", 1))
+    .And()
+    .Cluster(c => c.Eq("b", 2))
+    .ToListAsync();
+```
+
+## Operator Methods
+
+The `ClusterBuilder` provides convenience methods for every supported operator. You can also use the generic `.Catalyst()` method with any `Q.Operator`.
+
+### Comparison Operators
+
+| Method | Operator | SQL Generated |
+|--------|----------|---------------|
+| `.Eq(column, value)` | `Q.Operator.Eq` | `c["column"] = @param` |
+| `.NotEq(column, value)` | `Q.Operator.NotEq` | `c["column"] != @param` |
+| `.Gt(column, value)` | `Q.Operator.Gt` | `c["column"] > @param` |
+| `.Gte(column, value)` | `Q.Operator.Gte` | `c["column"] >= @param` |
+| `.Lt(column, value)` | `Q.Operator.Lt` | `c["column"] < @param` |
+| `.Lte(column, value)` | `Q.Operator.Lte` | `c["column"] <= @param` |
+
+```csharp
+galaxy.Query()
+    .Cluster(c => c
+        .Gte("price", 10.0)
+        .And().Lt("price", 100.0)
+        .And().NotEq("status", "archived"))
+    .ToListAsync();
+```
+
+### Pattern Matching
+
+| Method | Operator | SQL Generated |
+|--------|----------|---------------|
+| `.Like(column, pattern)` | `Q.Operator.Like` | `c["column"] LIKE @param` |
+| `.NotLike(column, pattern)` | `Q.Operator.NotLike` | `c["column"] NOT LIKE @param` |
+
+Patterns must include `%` wildcards:
+
+```csharp
+galaxy.Query()
+    .Cluster(c => c.Like("name", "%Test%").And().NotLike("code", "%DRAFT%"))
+    .ToListAsync();
+```
+
+### Existence Checks
+
+| Method | Operator | SQL Generated |
+|--------|----------|---------------|
+| `.Defined(column)` | `Q.Operator.Defined` | `IS_DEFINED(c["column"])` |
+| `.NotDefined(column)` | `Q.Operator.NotDefined` | `NOT IS_DEFINED(c["column"])` |
+
+```csharp
+galaxy.Query()
+    .Cluster(c => c.Defined("email").And().NotDefined("deletedAt"))
+    .ToListAsync();
+```
+
+### Array Operators
+
+| Method | Operator | SQL Generated | Use Case |
+|--------|----------|---------------|----------|
+| `.In(column, value)` | `Q.Operator.In` | `ARRAY_CONTAINS(c["column"], @param)` | Document's array field contains a scalar |
+| `.NotIn(column, value)` | `Q.Operator.NotIn` | `NOT ARRAY_CONTAINS(c["column"], @param)` | Document's array field does NOT contain a scalar |
+| `.Contains(column, values)` | `Q.Operator.Contains` | `ARRAY_CONTAINS(@param, c["column"])` | Scalar field value is in a provided collection |
+| `.NotContains(column, values)` | `Q.Operator.NotContains` | `NOT ARRAY_CONTAINS(@param, c["column"])` | Scalar field value is NOT in a provided collection |
+| `.Len(column, length)` | `Q.Operator.Len` | `ARRAY_LENGTH(c["column"]) = @param` | Array field has a specific length |
+
+```csharp
+// Check if a document's "tags" array contains "featured"
+galaxy.Query()
+    .Cluster(c => c.In("tags", "featured"))
+    .ToListAsync();
+
+// Check if the document's "category" is in a list of allowed values
+string[] allowed = ["Electronics", "Books", "Clothing"];
+galaxy.Query()
+    .Cluster(c => c.Contains("category", allowed))
+    .ToListAsync();
+
+// Find documents with exactly 3 items in their array
+galaxy.Query()
+    .Cluster(c => c.Len("items", 3))
+    .ToListAsync();
+```
+
+### Vector Distance Search
+
+| Method | Operator | SQL Generated |
+|--------|----------|---------------|
+| `.VectorDistance(column, vector)` | `Q.Operator.VectorDistance` | `VectorDistance(c["column"], @param) AS columnScore` |
+
+Requires `.Top()` to be set. See [VECTORDISTANCE_USAGE.md](VECTORDISTANCE_USAGE.md) for details.
+
+```csharp
+float[] queryVector = /* your embedding */;
+var (g, results) = await galaxy.Query()
+    .Select("name", "description")
+    .Top(10)
+    .Cluster(c => c.VectorDistance("descriptionEmbedding", queryVector))
+    .ToListAsync();
+```
+
+Multi-vector search with RRF (Reciprocal Rank Fusion):
+
+```csharp
+float[] titleVector = /* ... */;
+float[] descVector = /* ... */;
+var (g, results) = await galaxy.Query()
+    .Select("name", "description")
+    .Top(10)
+    .Cluster(c => c
+        .VectorDistance("titleEmbedding", titleVector)
+        .VectorDistance("descriptionEmbedding", descVector))
+    .ToListAsync();
+```
+
+### Full-Text Search
+
+| Method | Operator | SQL Generated |
+|--------|----------|---------------|
+| `.FTContains(column, keyword)` | `Q.Operator.FTContains` | `FullTextContains(c["column"], @param)` |
+| `.NotFTContains(column, keyword)` | `Q.Operator.NotFTContains` | `NOT FullTextContains(c["column"], @param)` |
+| `.FTContainsAll(column, keywords)` | `Q.Operator.FTContainsAll` | `FullTextContainsAll(c["column"], @param)` |
+| `.NotFTContainsAll(column, keywords)` | `Q.Operator.NotFTContainsAll` | `NOT FullTextContainsAll(c["column"], @param)` |
+| `.FTContainsAny(column, keywords)` | `Q.Operator.FTContainsAny` | `FullTextContainsAny(c["column"], @param)` |
+| `.NotFTContainsAny(column, keywords)` | `Q.Operator.NotFTContainsAny` | `NOT FullTextContainsAny(c["column"], @param)` |
+| `.FTScore(column, terms)` | `Q.Operator.FTScore` | `FullTextScore(c["column"], @param)` |
+
+See [FULLTEXT_USAGE.md](FULLTEXT_USAGE.md) for details.
+
+```csharp
+// Single keyword search
+galaxy.Query()
+    .Cluster(c => c.FTContains("description", "machine learning"))
+    .ToListAsync();
+
+// Must contain ALL keywords
+galaxy.Query()
+    .Cluster(c => c.FTContainsAll("description", ["machine", "learning", "algorithms"]))
+    .ToListAsync();
+
+// Must contain ANY keyword
+galaxy.Query()
+    .Cluster(c => c.FTContainsAny("description", ["AI", "ML", "deep learning"]))
+    .ToListAsync();
+
+// Relevance scoring with TOP
+galaxy.Query()
+    .Select("name", "description")
+    .Top(10)
+    .Cluster(c => c.FTScore("description", ["artificial", "intelligence"]))
+    .ToListAsync();
+```
+
+### Generic Catalyst Method
+
+For any operator, you can use the generic `.Catalyst()` method directly:
+
+```csharp
+galaxy.Query()
+    .Cluster(c => c
+        .Catalyst("name", "test", Q.Operator.Eq)
+        .And()
+        .Catalyst("price", 50.0, Q.Operator.Gt))
+    .ToListAsync();
+```
+
+## Column Selection
+
+### Select Specific Columns
+
+```csharp
+galaxy.Query()
+    .Select("id", "name", "price", "category")
+    .Cluster(c => c.Eq("status", "active"))
+    .ToListAsync();
+```
+
+### TOP and DISTINCT
+
+```csharp
+// Limit results
+galaxy.Query()
+    .Select("name", "price")
+    .Top(10)
+    .Cluster(c => c.Eq("category", "Electronics"))
+    .ToListAsync();
+
+// Distinct values
+galaxy.Query()
+    .Select("category")
+    .Distinct()
+    .Cluster(c => c.Defined("category"))
+    .ToListAsync();
+
+// Combined
+galaxy.Query()
+    .Select("category")
+    .Distinct()
+    .Top(5)
+    .Cluster(c => c.Defined("category"))
+    .ToListAsync();
+```
+
+## Sorting
+
+```csharp
+// Ascending (default)
+galaxy.Query()
+    .Cluster(c => c.Eq("category", "Books"))
+    .OrderBy("price")
+    .ToListAsync();
+
+// Descending
+galaxy.Query()
+    .Cluster(c => c.Eq("category", "Books"))
+    .OrderByDescending("price")
+    .ToListAsync();
+
+// Multiple sort columns
+galaxy.Query()
+    .Cluster(c => c.Eq("status", "active"))
+    .OrderBy("category")
+    .OrderByDescending("price")
+    .ToListAsync();
+
+// Weighted sorting for RRF (vector/full-text ranking)
+galaxy.Query()
+    .Select("name", "description")
+    .Top(10)
+    .Cluster(c => c
+        .VectorDistance("titleEmbedding", titleVector)
+        .VectorDistance("descriptionEmbedding", descVector))
+    .WithWeights("[0.8, 0.2]")
+    .ToListAsync();
+```
+
+## Aggregation
+
+```csharp
+galaxy.Query()
+    .Select("category")
+    .Aggregate("price", Q.Aggregate.Sum)
+    .Aggregate("price", Q.Aggregate.Avg)
+    .Aggregate("quantity", Q.Aggregate.Max)
+    .Aggregate("id", Q.Aggregate.Count)
+    .GroupBy("category")
+    .Cluster(c => c.Gte("addedOn", DateTime.Now.AddMonths(-3)))
+    .ToListAsync();
+```
+
+Supported aggregation functions: `Count`, `Sum`, `Min`, `Max`, `Avg`.
+
+## Pagination
+
+```csharp
+// First page
+var (g1, page1) = await galaxy.Query()
+    .Select("id", "name", "price")
+    .Paged(25)
+    .Cluster(c => c.Eq("status", "active"))
+    .OrderByDescending("addedOn")
+    .ToListAsync();
+
+// Next page using continuation token
+var (g2, page2) = await galaxy.Query()
+    .Select("id", "name", "price")
+    .Paged(25, g1.ContinuationToken)
+    .Cluster(c => c.Eq("status", "active"))
+    .OrderByDescending("addedOn")
+    .ToListAsync();
+```
+
+> **Note:** `.Paged()` and `.WithHints()` cannot be used together. Attempting to do so will throw an `UniverseException`.
+
+## Joins
+
+```csharp
+galaxy.Query()
+    .Join(arrayPath: "orders", alias: "o", columns: ["o.total", "o.date"])
+    .Cluster(c => c.Eq("status", "active"))
+    .ToListAsync();
+```
+
+## Query Hints
+
+```csharp
+galaxy.Query()
+    .Select("name", "price")
+    .Top(10)
+    .Cluster(c => c.Eq("category", "Electronics"))
+    .WithHints(new QueryHints(
+        MaxItemCount: 100,
+        EnableOptimisticDirectExecution: true))
+    .ToListAsync();
+```
+
+## Terminal Operations
+
+Every fluent chain must end with a terminal operation that executes or generates the query:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `.ToListAsync()` | `Task<(Gravity g, IList<T> T)>` | Execute and return a list of results |
+| `.ToListAsync<TS>()` | `Task<(Gravity g, IList<TS> T)>` | Execute with type projection |
+| `.GetAsync()` | `Task<(Gravity g, T T)>` | Execute and return the first matching result |
+| `.GetAsync<TS>()` | `Task<(Gravity g, TS S)>` | Get first result with type projection |
+| `.GenerateQuery()` | `Gravity` | Generate SQL without executing (for debugging) |
+
+All terminal operations return the same `Gravity` response object with RU consumption, continuation tokens, and optional query debug info.
+
+### Type Projection
+
+Project results to a different type (must implement `ICosmicEntity`):
+
+```csharp
+var (g, results) = await galaxy.Query()
+    .Select("id", "name", "price")
+    .Cluster(c => c.Eq("category", "Electronics"))
+    .ToListAsync<MyProjectedModel>();
+```
+
+### Query Generation (Debugging)
+
+Generate the SQL without executing it:
+
+```csharp
+Gravity queryInfo = galaxy.Query()
+    .Select("id", "name")
+    .Cluster(c => c.Like("code", "%SAMPLE%"))
+    .GenerateQuery();
+
+Console.WriteLine(queryInfo.Query.Value.Text);
+// Output: SELECT c["id"], c["name"] FROM c WHERE (c["code"] LIKE @param1)
+```
+
+## No-Filter Queries
+
+Omit `.Cluster()` entirely to query all documents:
+
+```csharp
+var (g, all) = await galaxy.Query()
+    .Select("id", "name")
+    .Top(100)
+    .ToListAsync();
+```
+
+## Chaining Order
+
+The fluent API allows methods to be called in any order (except terminal operations, which must be last). All state is accumulated and materialized when the terminal operation is called.
+
+```csharp
+// All of these are equivalent:
+galaxy.Query().Select("a").Cluster(c => c.Eq("b", 1)).Top(10).ToListAsync();
+galaxy.Query().Top(10).Cluster(c => c.Eq("b", 1)).Select("a").ToListAsync();
+galaxy.Query().Cluster(c => c.Eq("b", 1)).Select("a").Top(10).ToListAsync();
+```
+
+## Custom Alias
+
+All operator methods accept an optional `alias` parameter (defaults to `"c"`):
+
+```csharp
+galaxy.Query()
+    .Cluster(c => c.Eq("name", "test", alias: "doc"))
+    .ToListAsync();
+```
+
+## Complete Example
+
+```csharp
+// Complex multi-cluster query with all features
+var (gravity, results) = await galaxy.Query()
+    .Select("id", "name", "price", "category")
+    .Top(20)
+    .Cluster(c => c
+        .Like("name", "%Premium%")
+        .And().Gte("addedOn", DateTime.UtcNow.AddDays(-30))
+        .And().Lte("price", 500.0))
+    .Or()
+    .Cluster(c => c
+        .Eq("category", "Featured")
+        .And().Defined("promotionEndDate"))
+    .OrderByDescending("price")
+    .ToListAsync();
+
+Console.WriteLine($"Found {results.Count} items, consumed {gravity.RU} RU");
+```


### PR DESCRIPTION
## Summary
- Add `Orbit<T>` fluent query builder as a chainable alternative to declarative `Cluster`/`Catalyst` arrays, with convenience methods for all 20+ operators (Eq, Like, Defined, VectorDistance, FTContains, etc.)
- Add `ClusterBuilder` for composing filter conditions within clusters using `.And()` / `.Or()` chaining
- Add `.Query()` extension method on `IGalaxy<T>` as entry point; terminal methods (`.ToListAsync()`, `.GetAsync()`, `.GenerateQuery()`) delegate to existing Galaxy methods with identical return types
- Add 23 xUnit tests verifying SQL parity between fluent and declarative approaches across all operators, multi-cluster logic, aggregation, vector search, and full-text search
- Add comprehensive documentation (`docs/FLUENT_QUERY_BUILDER.md`) and README reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fluent query builder (Orbit<T>) with chainable cluster/condition builders and a .Query() extension on galaxy repositories.

* **Documentation**
  * README updated and new FLUENT_QUERY_BUILDER reference added with examples and full operator/reference surface.

* **Tests**
  * Added tests to verify parity between fluent and declarative query syntaxes; updated tests to use explicit typing.

* **Chores**
  * Version bumped to 3.3.0-preview.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->