### PR TITLE
feature: Native query builder naming policy from serializer

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-<Version>3.3.0</Version>
+<Version>3.3.1-preview.1</Version>

--- a/code/Universe/Builder/ClusterBuilder.cs
+++ b/code/Universe/Builder/ClusterBuilder.cs
@@ -10,6 +10,7 @@ public sealed class ClusterBuilder
     private Q.Where _nextWhere = Q.Where.And;
 
     /// <summary>Add a filter condition to this cluster.</summary>
+    /// <remarks>Azure Cosmos DB column names are case-sensitive. When a naming policy is configured on <see cref="UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.</remarks>
     public ClusterBuilder Catalyst(string column, object value = null,
         Q.Operator op = Q.Operator.Eq, string alias = "c")
     {

--- a/code/Universe/Builder/Options/UniverseSerializerOptions.cs
+++ b/code/Universe/Builder/Options/UniverseSerializerOptions.cs
@@ -8,16 +8,23 @@ public class UniverseSerializer : CosmosSerializer
 {
     private readonly JsonObjectSerializer SystemTextJsonSerializer;
 
+    /// <summary>The naming policy used for property name serialization and query column name conversion.</summary>
+    public JsonNamingPolicy NamingPolicy { get; }
+
     /// <summary></summary>
-    public UniverseSerializer(JsonNamingPolicy policy = null) => SystemTextJsonSerializer = new(new()
+    public UniverseSerializer(JsonNamingPolicy policy = null)
     {
-        PropertyNamingPolicy = policy,
-        PropertyNameCaseInsensitive = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
-        IgnoreReadOnlyFields = true,
-        IgnoreReadOnlyProperties = true
-    });
+        NamingPolicy = policy;
+        SystemTextJsonSerializer = new(new()
+        {
+            PropertyNamingPolicy = policy,
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
+            IgnoreReadOnlyFields = true,
+            IgnoreReadOnlyProperties = true
+        });
+    }
 
     /// <summary></summary>
     public override T FromStream<T>(Stream stream)

--- a/code/Universe/Builder/Orbit.cs
+++ b/code/Universe/Builder/Orbit.cs
@@ -24,6 +24,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 		=> _galaxy = galaxy;
 
 	/// <summary>Add a cluster of filter conditions using a builder lambda.</summary>
+	/// <remarks>Azure Cosmos DB column names are case-sensitive. When a naming policy is configured on <see cref="UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.</remarks>
 	public Orbit<T> Cluster(Action<ClusterBuilder> configure)
 	{
 		ArgumentNullException.ThrowIfNull(configure);
@@ -47,6 +48,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	}
 
 	/// <summary>Specify which columns to select.</summary>
+	/// <remarks>Azure Cosmos DB column names are case-sensitive. When a naming policy is configured on <see cref="UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.</remarks>
 	public Orbit<T> Select(params string[] columns)
 	{
 		ArgumentNullException.ThrowIfNull(columns);
@@ -71,6 +73,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	}
 
 	/// <summary>Add a sort order.</summary>
+	/// <remarks>Azure Cosmos DB column names are case-sensitive. When a naming policy is configured on <see cref="UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.</remarks>
 	public Orbit<T> OrderBy(string column, Sorting.Direction direction = Sorting.Direction.ASC, string alias = "c")
 	{
 		_sortingOptions.Add(new(column, direction, alias));
@@ -99,6 +102,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	}
 
 	/// <summary>Add GROUP BY columns.</summary>
+	/// <remarks>Azure Cosmos DB column names are case-sensitive. When a naming policy is configured on <see cref="UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.</remarks>
 	public Orbit<T> GroupBy(params string[] columns)
 	{
 		ArgumentNullException.ThrowIfNull(columns);

--- a/code/Universe/Builder/QueryBuilder.cs
+++ b/code/Universe/Builder/QueryBuilder.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Universe.Response;
 using Universe.Builder.Strategies;
 
@@ -8,21 +9,24 @@ internal class UniverseBuilder : IDisposable
     private readonly bool _recordQueries;
     private readonly QueryTuner _queryTuner;
     private readonly QueryStrategySelector _strategySelector;
+    private readonly JsonNamingPolicy _namingPolicy;
 
     public UniverseBuilder() : this(false)
     {
     }
 
-    public UniverseBuilder(bool recordQueries)
+    public UniverseBuilder(bool recordQueries, JsonNamingPolicy namingPolicy = null)
     {
         _recordQueries = recordQueries;
+        _namingPolicy = namingPolicy;
         _queryTuner = new();
         _strategySelector = new(_queryTuner);
     }
 
-    public UniverseBuilder(bool recordQueries, QueryTuner queryTuner)
+    public UniverseBuilder(bool recordQueries, QueryTuner queryTuner, JsonNamingPolicy namingPolicy = null)
     {
         _recordQueries = recordQueries;
+        _namingPolicy = namingPolicy;
         _queryTuner = queryTuner;
         _strategySelector = new(_queryTuner);
     }
@@ -125,7 +129,7 @@ internal class UniverseBuilder : IDisposable
             // SQL Injection mitigation: join.Alias and join.ArrayPath are validated by SanitizeInputs() at line 24
             // ValidateIdentifier() rejects SQL keywords (;, --, /*, */), brackets (]), quotes ("), and control characters
             JoinOptions join = columnOptions.Value.Join;
-            queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{join.ArrayPath}");
+            queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{ConvertName(join.ArrayPath)}");
 
             // Add join columns to the select if specified
             if (join.Columns?.Any() == true)
@@ -134,7 +138,7 @@ internal class UniverseBuilder : IDisposable
                 // ValidateIdentifier() rejects SQL keywords (;, --, /*, */), brackets (]), quotes ("), and control characters
                 string joinColumns = string.Join(", ", join.Columns.Select(col => FormatProperty(join.Alias, col)));
                 columnsInQuery = columnsInQuery == "*" ? $"c.*, {joinColumns}" : $"{columnsInQuery}, {joinColumns}";
-                queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{join.ArrayPath}");
+                queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{ConvertName(join.ArrayPath)}");
             }
 
             // Handle join aggregates
@@ -165,7 +169,7 @@ internal class UniverseBuilder : IDisposable
 
                 // SQL Injection mitigation: join.Alias and join.ArrayPath are validated by SanitizeInputs() at line 24
                 // ValidateIdentifier() rejects SQL keywords (;, --, /*, */), brackets (]), quotes ("), and control characters
-                queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{join.ArrayPath}");
+                queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{ConvertName(join.ArrayPath)}");
             }
         }
 
@@ -443,7 +447,9 @@ internal class UniverseBuilder : IDisposable
             throw new UniverseException($"{parameterName} contains control characters.");
     }
 
-    private static string WhereClauseBuilder(Catalyst catalyst)
+    private string ConvertName(string name) => _namingPolicy?.ConvertName(name) ?? name;
+
+    private string WhereClauseBuilder(Catalyst catalyst)
     {
         string alias = catalyst.Alias ?? "c";
         string formattedProperty = FormatProperty(alias, catalyst.Column);
@@ -466,10 +472,11 @@ internal class UniverseBuilder : IDisposable
         };
     }
 
-    private static string FormatProperty(string alias, string column)
+    private string FormatProperty(string alias, string column)
     {
         // Handle nested JSON paths by splitting on '.' and wrapping each segment
         // Example: "metadata.sku" becomes alias["metadata"]["sku"]
+        // Naming policy is applied to each segment to match serialized document field names
 
         string[] segments = column.Split('.');
         StringBuilder result = new(alias);
@@ -477,7 +484,7 @@ internal class UniverseBuilder : IDisposable
         foreach (string segment in segments)
         {
             if (!string.IsNullOrWhiteSpace(segment))
-                result.Append($"[\"{segment}\"]");
+                result.Append($"[\"{ConvertName(segment)}\"]");
         }
 
         return result.ToString();

--- a/code/Universe/Builder/QueryBuilder.cs
+++ b/code/Universe/Builder/QueryBuilder.cs
@@ -129,7 +129,7 @@ internal class UniverseBuilder : IDisposable
             // SQL Injection mitigation: join.Alias and join.ArrayPath are validated by SanitizeInputs() at line 24
             // ValidateIdentifier() rejects SQL keywords (;, --, /*, */), brackets (]), quotes ("), and control characters
             JoinOptions join = columnOptions.Value.Join;
-            queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{ConvertName(join.ArrayPath)}");
+            queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN {FormatProperty("c", join.ArrayPath)}");
 
             // Add join columns to the select if specified
             if (join.Columns?.Any() == true)
@@ -138,7 +138,7 @@ internal class UniverseBuilder : IDisposable
                 // ValidateIdentifier() rejects SQL keywords (;, --, /*, */), brackets (]), quotes ("), and control characters
                 string joinColumns = string.Join(", ", join.Columns.Select(col => FormatProperty(join.Alias, col)));
                 columnsInQuery = columnsInQuery == "*" ? $"c.*, {joinColumns}" : $"{columnsInQuery}, {joinColumns}";
-                queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{ConvertName(join.ArrayPath)}");
+                queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN {FormatProperty("c", join.ArrayPath)}");
             }
 
             // Handle join aggregates
@@ -169,7 +169,7 @@ internal class UniverseBuilder : IDisposable
 
                 // SQL Injection mitigation: join.Alias and join.ArrayPath are validated by SanitizeInputs() at line 24
                 // ValidateIdentifier() rejects SQL keywords (;, --, /*, */), brackets (]), quotes ("), and control characters
-                queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN c.{ConvertName(join.ArrayPath)}");
+                queryBuilder = new($"SELECT {columnsInQuery} FROM c JOIN {join.Alias} IN {FormatProperty("c", join.ArrayPath)}");
             }
         }
 

--- a/code/Universe/Extensions/StrExtensions.cs
+++ b/code/Universe/Extensions/StrExtensions.cs
@@ -1,5 +1,3 @@
-// create an extension method to convert a string to lower camel case
-
 using System.Text.RegularExpressions;
 
 namespace Universe.Extensions;
@@ -9,21 +7,25 @@ namespace Universe.Extensions;
 /// </summary>
 public static class StringExtensions
 {
-    /// <summary>
-    /// Converts a string to lower camel case.
-    /// </summary>
-    /// <param name="str"></param>
-    /// <returns></returns>
-    public static string ToLowerCamelCase(this string str)
+    extension(string str)
     {
-        if (string.IsNullOrWhiteSpace(str))
-            return str;
+        /// <summary>
+        /// Converts a string to lower camel case.
+        /// This is a general-purpose utility. For query builder column names, prefer configuring
+        /// a <see cref="System.Text.Json.JsonNamingPolicy"/> on <see cref="Builder.Options.UniverseSerializer"/>
+        /// which automatically transforms column names in queries to match serialized document field names.
+        /// </summary>
+        public string ToLowerCamelCase()
+        {
+            if (string.IsNullOrWhiteSpace(str))
+                return str;
 
-        str = Regex.Replace(str, @"_([a-zA-Z])", m => m.Groups[1].Value.ToUpper());
+            string result = Regex.Replace(str, @"_([a-zA-Z])", m => m.Groups[1].Value.ToUpper());
 
-        if (Regex.IsMatch(str, @"^[A-Z0-9]+$"))
-            return char.ToLowerInvariant(str[0]) + str[1..];
+            if (Regex.IsMatch(result, @"^[A-Z0-9]+$"))
+                return char.ToLowerInvariant(result[0]) + result[1..];
 
-        return $"{char.ToLowerInvariant(str[0])}{str[1..]}";
+            return $"{char.ToLowerInvariant(result[0])}{result[1..]}";
+        }
     }
 }

--- a/code/Universe/Extensions/StrExtensions.cs
+++ b/code/Universe/Extensions/StrExtensions.cs
@@ -22,10 +22,7 @@ public static class StringExtensions
 
             string result = Regex.Replace(str, @"_([a-zA-Z])", m => m.Groups[1].Value.ToUpper());
 
-            if (Regex.IsMatch(result, @"^[A-Z0-9]+$"))
-                return char.ToLowerInvariant(result[0]) + result[1..];
-
-            return $"{char.ToLowerInvariant(result[0])}{result[1..]}";
+            return char.ToLowerInvariant(result[0]) + result[1..];
         }
     }
 }

--- a/code/Universe/GalaxyBasic.cs
+++ b/code/Universe/GalaxyBasic.cs
@@ -27,7 +27,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
         string database,
         string container,
         IReadOnlyList<string> partitionKey,
-        bool recordQueries = false) : base(client, database, container, partitionKey, recordQueries) => QBuilder = new(_recordQuery);
+        bool recordQueries = false) : base(client, database, container, partitionKey, recordQueries) => QBuilder = new(_recordQuery, _namingPolicy);
 
     /// <summary>Create a new Galaxy with custom Universe options</summary>
     protected GalaxyBasic(
@@ -40,7 +40,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
     {
         ArgumentNullException.ThrowIfNull(options);
         QueryTuner queryTuner = new(options.StatisticsStorage);
-        QBuilder = new(_recordQuery, queryTuner);
+        QBuilder = new(_recordQuery, queryTuner, _namingPolicy);
     }
 
     async Task<(Gravity, string)> IGalaxyBasic<T>.Create(T model)

--- a/code/Universe/GalaxyCore.cs
+++ b/code/Universe/GalaxyCore.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Universe;
 
 /// <summary>
@@ -9,6 +11,7 @@ public abstract class GalaxyCore : IDisposable
 
     internal readonly bool _recordQuery;
     internal readonly bool _allowBulk;
+    internal readonly JsonNamingPolicy _namingPolicy;
 
     /// <summary></summary>
     protected GalaxyCore(CosmosClient client, string database, string container, IReadOnlyList<string> partitionKey, bool recordQueries = false)
@@ -25,7 +28,11 @@ public abstract class GalaxyCore : IDisposable
 
         _recordQuery = recordQueries;
         if (client.ClientOptions is not null)
+        {
             _allowBulk = client.ClientOptions.AllowBulkExecution;
+            if (client.ClientOptions.Serializer is UniverseSerializer universeSerializer)
+                _namingPolicy = universeSerializer.NamingPolicy;
+        }
         _container = client.GetDatabase(database).CreateContainerIfNotExistsAsync(containerProps).GetAwaiter().GetResult();
     }
 

--- a/code/Universe/UniverseQuery.csproj
+++ b/code/Universe/UniverseQuery.csproj
@@ -21,13 +21,13 @@
 		<RepositoryType>Git</RepositoryType>
 		<Authors>norarrsgd</Authors>
 		<Product>Universe</Product>
-		<Version>3.3.0</Version>
+		<Version>3.3.1-preview.1</Version>
 		<PackageReleaseNotes>
 			View release on
 			https://github.com/norarrsgd/universe/releases/tag/untagged-cdcf4202c2656450c07b
 		</PackageReleaseNotes>
-		<AssemblyVersion>3.3.0.0</AssemblyVersion>
-		<FileVersion>3.3.0.0</FileVersion>
+		<AssemblyVersion>3.3.1.0</AssemblyVersion>
+		<FileVersion>3.3.1.0</FileVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -39,6 +39,7 @@
         </member>
         <member name="M:Universe.Builder.ClusterBuilder.Catalyst(System.String,System.Object,Universe.Builder.Options.Q.Operator,System.String)">
             <summary>Add a filter condition to this cluster.</summary>
+            <remarks>Azure Cosmos DB column names are case-sensitive. When a naming policy is configured on <see cref="T:Universe.Builder.Options.UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.</remarks>
         </member>
         <member name="M:Universe.Builder.ClusterBuilder.And">
             <summary>The next condition will be joined with AND.</summary>
@@ -461,6 +462,9 @@
         <member name="T:Universe.Builder.Options.UniverseSerializer">
             <summary></summary>
         </member>
+        <member name="P:Universe.Builder.Options.UniverseSerializer.NamingPolicy">
+            <summary>The naming policy used for property name serialization and query column name conversion.</summary>
+        </member>
         <member name="M:Universe.Builder.Options.UniverseSerializer.#ctor(System.Text.Json.JsonNamingPolicy)">
             <summary></summary>
         </member>
@@ -497,6 +501,7 @@
         </member>
         <member name="M:Universe.Builder.Orbit`1.Cluster(System.Action{Universe.Builder.ClusterBuilder})">
             <summary>Add a cluster of filter conditions using a builder lambda.</summary>
+            <remarks>Azure Cosmos DB column names are case-sensitive. When a naming policy is configured on <see cref="T:Universe.Builder.Options.UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.</remarks>
         </member>
         <member name="M:Universe.Builder.Orbit`1.Or">
             <summary>The next cluster will be joined with OR.</summary>
@@ -506,6 +511,7 @@
         </member>
         <member name="M:Universe.Builder.Orbit`1.Select(System.String[])">
             <summary>Specify which columns to select.</summary>
+            <remarks>Azure Cosmos DB column names are case-sensitive. When a naming policy is configured on <see cref="T:Universe.Builder.Options.UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.</remarks>
         </member>
         <member name="M:Universe.Builder.Orbit`1.Distinct">
             <summary>Return only distinct results.</summary>
@@ -515,6 +521,7 @@
         </member>
         <member name="M:Universe.Builder.Orbit`1.OrderBy(System.String,Universe.Builder.Options.Sorting.Direction,System.String)">
             <summary>Add a sort order.</summary>
+            <remarks>Azure Cosmos DB column names are case-sensitive. When a naming policy is configured on <see cref="T:Universe.Builder.Options.UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.</remarks>
         </member>
         <member name="M:Universe.Builder.Orbit`1.OrderByDescending(System.String,System.String)">
             <summary>Add descending sort order on a column.</summary>
@@ -527,6 +534,7 @@
         </member>
         <member name="M:Universe.Builder.Orbit`1.GroupBy(System.String[])">
             <summary>Add GROUP BY columns.</summary>
+            <remarks>Azure Cosmos DB column names are case-sensitive. When a naming policy is configured on <see cref="T:Universe.Builder.Options.UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.</remarks>
         </member>
         <member name="M:Universe.Builder.Orbit`1.Paged(System.Int32,System.String)">
             <summary>Enable pagination with specified page size.</summary>
@@ -1024,11 +1032,15 @@
             </summary>
         </member>
         <member name="M:Universe.Extensions.StringExtensions.ToLowerCamelCase(System.String)">
+            <inheritdoc cref="M:Universe.Extensions.StringExtensions.&lt;G&gt;$34505F560D9EACF86A87F3ED1F85E448.ToLowerCamelCase"/>
+        </member>
+        <member name="M:Universe.Extensions.StringExtensions.&lt;G&gt;$34505F560D9EACF86A87F3ED1F85E448.ToLowerCamelCase">
             <summary>
             Converts a string to lower camel case.
+            This is a general-purpose utility. For query builder column names, prefer configuring
+            a <see cref="T:System.Text.Json.JsonNamingPolicy"/> on <see cref="T:Universe.Builder.Options.UniverseSerializer"/>
+            which automatically transforms column names in queries to match serialized document field names.
             </summary>
-            <param name="str"></param>
-            <returns></returns>
         </member>
         <member name="T:Universe.Galaxy`1">
             <summary>Inherit repositories to implement a more advanced Universe</summary>


### PR DESCRIPTION
## Summary
- Query builder now infers `JsonNamingPolicy` from `UniverseSerializer` via `CosmosClient.ClientOptions.Serializer`, automatically transforming column names (Select, Cluster, OrderBy, GroupBy, Join) to match serialized document field names — eliminates manual `.ToLowerCamelCase()` on every `nameof()` call
- Exposes `NamingPolicy` property on `UniverseSerializer` and threads it through `GalaxyCore` → `GalaxyBasic` → `UniverseBuilder` → `FormatProperty`, using the same `ClientOptions` pattern as `AllowBulkExecution`
- Rewrites `ToLowerCamelCase` extension using C# 14 `extension` block syntax with XML doc noting it is no longer needed for query builder column names
- Adds XML `<remarks>` to Orbit and ClusterBuilder query methods documenting Cosmos DB case sensitivity and automatic naming policy behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configurable JSON naming policies so queries use serialized field names.

* **Documentation**
  * Clarified that Cosmos DB column names are case-sensitive and documented how naming policies affect query column names.

* **Chores**
  * Updated project version to 3.3.1-preview.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->