### PR TITLE
feature: type-based projection Select<T>() for Orbit

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-<Version>3.3.1-preview.2</Version>
+<Version>3.3.1-preview.3</Version>

--- a/code/DarkMatter/Examples/Example16_ProjectionSelect.cs
+++ b/code/DarkMatter/Examples/Example16_ProjectionSelect.cs
@@ -1,0 +1,132 @@
+using System.Text.Json.Serialization;
+using DarkMatter.Models;
+using Universe.Extensions;
+using Universe.Interfaces;
+using Universe.Response;
+
+namespace DarkMatter.Examples;
+
+public class Example16_ProjectionSelect(IGalaxy<MyObject> galaxy) : ExampleBase(galaxy)
+{
+	public override Task<double> RunAsync()
+	{
+		Console.WriteLine("\n=== EXAMPLE 16: Type-Based Projection Select ===\n");
+
+		// ── 1. Basic projection: extract columns from a record ──────────────
+		Console.WriteLine("1. Basic Projection — Select<ProductSummary>():");
+		Console.WriteLine("   Instead of .Select(\"Name\", \"Price\", \"Category\")");
+		Console.WriteLine("   use the type's properties as the column list.\n");
+
+		Gravity q1 = galaxy.Query()
+			.Select<ProductSummary>()
+			.Cluster(c => c.Gte("Price", 50.0))
+			.GenerateQuery();
+
+		Console.WriteLine($"   SQL: {q1.Query.Text}");
+		Console.WriteLine();
+
+		// ── 2. Projection with [JsonIgnore] ─────────────────────────────────
+		Console.WriteLine("2. Projection with [JsonIgnore] — excluded properties:");
+		Console.WriteLine("   InventoryView has a [JsonIgnore] on IsLowStock,");
+		Console.WriteLine("   so it does NOT appear in the SELECT clause.\n");
+
+		Gravity q2 = galaxy.Query()
+			.Select<InventoryView>()
+			.Cluster(c => c.Gt("Quantity", 0))
+			.GenerateQuery();
+
+		Console.WriteLine($"   SQL: {q2.Query.Text}");
+		Console.WriteLine();
+
+		// ── 3. Combining projection + extra string columns ──────────────────
+		Console.WriteLine("3. Combining Select<T>() with Select(string) — additive:");
+		Console.WriteLine("   Start with ProductSummary columns, then add Description.\n");
+
+		Gravity q3 = galaxy.Query()
+			.Select<ProductSummary>()
+			.Select("Description")
+			.Cluster(c => c.Like("Name", "%Widget%"))
+			.GenerateQuery();
+
+		Console.WriteLine($"   SQL: {q3.Query.Text}");
+		Console.WriteLine();
+
+		// ── 4. Projection with struct (value type) ──────────────────────────
+		Console.WriteLine("4. Projection with record struct:");
+		Console.WriteLine("   Select<T>() works with classes, records, structs, and record structs.\n");
+
+		Gravity q4 = galaxy.Query()
+			.Select<PricePoint>()
+			.Top(10)
+			.Cluster(c => c.Eq("Category", "Electronics"))
+			.OrderBy("Price")
+			.GenerateQuery();
+
+		Console.WriteLine($"   SQL: {q4.Query.Text}");
+		Console.WriteLine();
+
+		// ── 5. Projection with inherited type ───────────────────────────────
+		Console.WriteLine("5. Projection with inheritance — includes base + derived properties:");
+		Console.WriteLine("   DetailedProductView inherits from ProductSummary and adds Description.\n");
+
+		Gravity q5 = galaxy.Query()
+			.Select<DetailedProductView>()
+			.Cluster(c => c.Defined("Description"))
+			.GenerateQuery();
+
+		Console.WriteLine($"   SQL: {q5.Query.Text}");
+		Console.WriteLine();
+
+		// ── 6. Side-by-side: string Select vs projection Select ─────────────
+		Console.WriteLine("6. Side-by-side comparison — identical SQL output:");
+
+		Gravity manual = galaxy.Query()
+			.Select("Name", "Price", "Category")
+			.Cluster(c => c.Eq("Code", "ABC"))
+			.GenerateQuery();
+
+		Gravity typed = galaxy.Query()
+			.Select<ProductSummary>()
+			.Cluster(c => c.Eq("Code", "ABC"))
+			.GenerateQuery();
+
+		Console.WriteLine($"   String: {manual.Query.Text}");
+		Console.WriteLine($"   Typed:  {typed.Query.Text}");
+		Console.WriteLine();
+
+		Console.WriteLine("Projection select examples completed successfully!");
+		return Task.FromResult(0.0);
+	}
+}
+
+// ── Projection types used in examples ───────────────────────────────────────
+
+/// <summary>Lightweight projection for product listing pages.</summary>
+record ProductSummary
+{
+	public string Name { get; init; }
+	public double Price { get; init; }
+	public string Category { get; init; }
+}
+
+/// <summary>Inventory view — IsLowStock is computed client-side and excluded from SELECT.</summary>
+record InventoryView
+{
+	public string Code { get; init; }
+	public string Name { get; init; }
+	public int Quantity { get; init; }
+	[JsonIgnore] public bool IsLowStock => Quantity < 10;
+}
+
+/// <summary>Value-type projection for chart/graph data points.</summary>
+record struct PricePoint
+{
+	public string Code { get; init; }
+	public double Price { get; init; }
+}
+
+/// <summary>Extended projection inheriting base columns and adding Description.</summary>
+record DetailedProductView : ProductSummary
+{
+	public string Description { get; init; }
+}

--- a/code/DarkMatter/Program.cs
+++ b/code/DarkMatter/Program.cs
@@ -62,6 +62,7 @@ class Program
         totalRu += await new Example13_QueryOptimization(vectorGalaxy).RunAsync();
         totalRu += await new Example14_SqlInjectionProtection(galaxy).RunAsync();
         totalRu += await new Example15_ContainsOperator(galaxy).RunAsync();
+        totalRu += await new Example16_ProjectionSelect(galaxy).RunAsync();
 
         // Display summary information
         Console.WriteLine($"\nTotal RU spent across all examples: {totalRu}");

--- a/code/Universe.Tests/Builder/NamingPolicyQueryTests.cs
+++ b/code/Universe.Tests/Builder/NamingPolicyQueryTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Universe.Builder;
 using Universe.Builder.Options;
-using Universe.Interfaces;
 using Xunit;
 
 namespace Universe.Tests.Builder;

--- a/code/Universe.Tests/Builder/ProjectionSelectTests.cs
+++ b/code/Universe.Tests/Builder/ProjectionSelectTests.cs
@@ -1,0 +1,214 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Universe.Builder;
+using Universe.Builder.Options;
+using Universe.Extensions;
+using Xunit;
+
+namespace Universe.Tests.Builder;
+
+/// <summary>
+/// Tests for the type-based Select&lt;TProjection&gt;() method on Orbit,
+/// including property extraction, filtering, and SQL generation.
+/// </summary>
+public sealed class ProjectionSelectTests : IDisposable
+{
+	private readonly UniverseBuilder _builder = new(recordQueries: true);
+	private readonly UniverseBuilder _camel = new(recordQueries: true, namingPolicy: JsonNamingPolicy.CamelCase);
+
+	private static readonly Regex ParameterNormalizer = new(@"@\w+", RegexOptions.Compiled);
+	private static string Normalize(string sql) => ParameterNormalizer.Replace(sql, "@p");
+
+	public void Dispose()
+	{
+		_builder.Dispose();
+		_camel.Dispose();
+	}
+
+	#region Property Extraction
+
+	[Fact]
+	public void Select_ExtractsAllPublicProperties()
+	{
+		Orbit<TestEntity> orbit = new(null);
+		orbit.Select<SimpleProjection>();
+		(_, ColumnOptions? colOpts, _, _) = orbit.Build();
+
+		Assert.NotNull(colOpts);
+		Assert.Contains("Name", colOpts.Value.Names);
+		Assert.Contains("Price", colOpts.Value.Names);
+		Assert.Equal(2, colOpts.Value.Names.Count);
+	}
+
+	[Fact]
+	public void Select_ExcludesJsonIgnoreProperties()
+	{
+		Orbit<TestEntity> orbit = new(null);
+		orbit.Select<ProjectionWithIgnore>();
+		(_, ColumnOptions? colOpts, _, _) = orbit.Build();
+
+		Assert.NotNull(colOpts);
+		Assert.Contains("Name", colOpts.Value.Names);
+		Assert.DoesNotContain("Secret", colOpts.Value.Names);
+		Assert.Single(colOpts.Value.Names);
+	}
+
+	[Fact]
+	public void Select_IncludesInheritedProperties()
+	{
+		Orbit<TestEntity> orbit = new(null);
+		orbit.Select<DerivedProjection>();
+		(_, ColumnOptions? colOpts, _, _) = orbit.Build();
+
+		Assert.NotNull(colOpts);
+		Assert.Contains("Name", colOpts.Value.Names);
+		Assert.Contains("Price", colOpts.Value.Names);
+		Assert.Contains("Category", colOpts.Value.Names);
+		Assert.Equal(3, colOpts.Value.Names.Count);
+	}
+
+	[Fact]
+	public void Select_EmptyProjection_ProducesNoColumns()
+	{
+		Orbit<TestEntity> orbit = new(null);
+		orbit.Select<EmptyProjection>();
+		(_, ColumnOptions? colOpts, _, _) = orbit.Build();
+
+		Assert.Null(colOpts);
+	}
+
+	[Fact]
+	public void Select_WorksWithRecordStruct()
+	{
+		Orbit<TestEntity> orbit = new(null);
+		orbit.Select<StructProjection>();
+		(_, ColumnOptions? colOpts, _, _) = orbit.Build();
+
+		Assert.NotNull(colOpts);
+		Assert.Contains("Name", colOpts.Value.Names);
+		Assert.Contains("Price", colOpts.Value.Names);
+		Assert.Equal(2, colOpts.Value.Names.Count);
+	}
+
+	#endregion
+
+	#region Combining with String Select
+
+	[Fact]
+	public void Select_CombinesWithStringSelect()
+	{
+		Orbit<TestEntity> orbit = new(null);
+		orbit.Select<SimpleProjection>().Select("Extra");
+		(_, ColumnOptions? colOpts, _, _) = orbit.Build();
+
+		Assert.NotNull(colOpts);
+		Assert.Contains("Name", colOpts.Value.Names);
+		Assert.Contains("Price", colOpts.Value.Names);
+		Assert.Contains("Extra", colOpts.Value.Names);
+		Assert.Equal(3, colOpts.Value.Names.Count);
+	}
+
+	[Fact]
+	public void Select_StringThenProjection_CombinesBoth()
+	{
+		Orbit<TestEntity> orbit = new(null);
+		orbit.Select("Extra").Select<SimpleProjection>();
+		(_, ColumnOptions? colOpts, _, _) = orbit.Build();
+
+		Assert.NotNull(colOpts);
+		Assert.Contains("Extra", colOpts.Value.Names);
+		Assert.Contains("Name", colOpts.Value.Names);
+		Assert.Contains("Price", colOpts.Value.Names);
+		Assert.Equal(3, colOpts.Value.Names.Count);
+	}
+
+	#endregion
+
+	#region SQL Generation
+
+	[Fact]
+	public void Select_GeneratesSameSqlAsStringSelect()
+	{
+		// Projection-based
+		Orbit<TestEntity> projection = new(null);
+		projection.Select<SimpleProjection>().Cluster(c => c.Eq("category", "test"));
+		(var pClusters, ColumnOptions? pColOpts, var pSort, var pGroups) = projection.Build();
+		string projectionSql = _builder.CreateQuery(pClusters, pColOpts, pSort, pGroups).QueryText;
+
+		// String-based (same column names)
+		Orbit<TestEntity> manual = new(null);
+		manual.Select("Name", "Price").Cluster(c => c.Eq("category", "test"));
+		(var mClusters, ColumnOptions? mColOpts, var mSort, var mGroups) = manual.Build();
+		string manualSql = _builder.CreateQuery(mClusters, mColOpts, mSort, mGroups).QueryText;
+
+		Assert.Equal(Normalize(manualSql), Normalize(projectionSql));
+	}
+
+	[Fact]
+	public void Select_NamingPolicyAppliedToExtractedNames()
+	{
+		Orbit<TestEntity> orbit = new(null);
+		orbit.Select<SimpleProjection>();
+		(var clusters, ColumnOptions? colOpts, var sorting, var groups) = orbit.Build();
+		string sql = _camel.CreateQuery(clusters, colOpts, sorting, groups).QueryText;
+
+		Assert.Contains("c[\"name\"]", sql);
+		Assert.Contains("c[\"price\"]", sql);
+		Assert.DoesNotContain("c[\"Name\"]", sql);
+		Assert.DoesNotContain("c[\"Price\"]", sql);
+	}
+
+	#endregion
+
+	#region Cache Behavior
+
+	[Fact]
+	public void Cache_ReturnsSameInstanceForSameType()
+	{
+		IReadOnlyList<string> first = ProjectionColumnExtractor.GetColumnNames<SimpleProjection>();
+		IReadOnlyList<string> second = ProjectionColumnExtractor.GetColumnNames<SimpleProjection>();
+
+		Assert.Same(first, second);
+	}
+
+	[Fact]
+	public void Cache_ReturnsDifferentInstancesForDifferentTypes()
+	{
+		IReadOnlyList<string> simple = ProjectionColumnExtractor.GetColumnNames<SimpleProjection>();
+		IReadOnlyList<string> derived = ProjectionColumnExtractor.GetColumnNames<DerivedProjection>();
+
+		Assert.NotSame(simple, derived);
+	}
+
+	#endregion
+}
+
+#region Test Projection Types
+
+internal record SimpleProjection
+{
+	public string Name { get; set; }
+	public decimal Price { get; set; }
+}
+
+internal record ProjectionWithIgnore
+{
+	public string Name { get; set; }
+	[JsonIgnore] public string Secret { get; set; }
+}
+
+internal record DerivedProjection : SimpleProjection
+{
+	public string Category { get; set; }
+}
+
+internal record EmptyProjection;
+
+internal record struct StructProjection
+{
+	public string Name { get; set; }
+	public decimal Price { get; set; }
+}
+
+#endregion

--- a/code/Universe/Builder/Orbit.cs
+++ b/code/Universe/Builder/Orbit.cs
@@ -56,6 +56,18 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 		return this;
 	}
 
+	/// <summary>Specify which columns to select based on the public properties of a projection type.</summary>
+	/// <remarks>
+	/// Extracts all public instance property names from <typeparamref name="TProjection"/>, excluding properties marked with <see cref="System.Text.Json.Serialization.JsonIgnoreAttribute"/>.
+	/// When a naming policy is configured on <see cref="UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.
+	/// This method is additive — it can be combined with <see cref="Select(string[])"/> to include additional columns.
+	/// </remarks>
+	public Orbit<T> Select<TProjection>()
+	{
+		_columns.AddRange(ProjectionColumnExtractor.GetColumnNames<TProjection>());
+		return this;
+	}
+
 	/// <summary>Return only distinct results.</summary>
 	public Orbit<T> Distinct()
 	{
@@ -145,7 +157,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	}
 
 	/// <summary>Execute the query and return a list of results projected to a different type.</summary>
-	public async Task<(Gravity g, IList<TS> T)> ToListAsync<TS>() where TS : ICosmicEntity
+	public async Task<(Gravity g, IList<TS> T)> ToListAsync<TS>()
 	{
 		ValidateQueryConstraints();
 		(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> groups) = Build();
@@ -183,7 +195,7 @@ public sealed class Orbit<T> where T : class, ICosmicEntity
 	/// Only filter conditions (clusters) and column selection (Select) are applied.
 	/// Top, Distinct, Aggregate, GroupBy, sorting, Join, Paged, and WithHints options are ignored. Use ToListAsync for those features.
 	/// </remarks>
-	public async Task<(Gravity g, TS S)> GetAsync<TS>() where TS : ICosmicEntity
+	public async Task<(Gravity g, TS S)> GetAsync<TS>()
 	{
 		ValidateQueryConstraints();
 		(IReadOnlyList<Cluster> clusters, _, _, _) = Build();

--- a/code/Universe/Extensions/ProjectionColumnExtractor.cs
+++ b/code/Universe/Extensions/ProjectionColumnExtractor.cs
@@ -17,7 +17,10 @@ internal static class ProjectionColumnExtractor
 	internal static IReadOnlyList<string> GetColumnNames<T>()
 		=> Cache.GetOrAdd(typeof(T), static type =>
 			type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-				.Where(p => p.CanRead && p.GetCustomAttribute<JsonIgnoreAttribute>() is null)
+				.Where(p => p.CanRead
+				            && p.GetIndexParameters().Length == 0
+				            && p.GetCustomAttribute<JsonIgnoreAttribute>() is null)
 				.Select(p => p.Name)
-				.ToList());
+				.ToList()
+				.AsReadOnly());
 }

--- a/code/Universe/Extensions/ProjectionColumnExtractor.cs
+++ b/code/Universe/Extensions/ProjectionColumnExtractor.cs
@@ -1,0 +1,23 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace Universe.Extensions;
+
+/// <summary>
+/// Extracts column names from a type's public properties for use with <see cref="Builder.Orbit{T}.Select{TProjection}"/>.
+/// Results are cached per type for performance.
+/// </summary>
+internal static class ProjectionColumnExtractor
+{
+	private static readonly ConcurrentDictionary<Type, IReadOnlyList<string>> Cache = [];
+
+	/// <summary>
+	/// Returns the public instance property names for the given type, excluding properties marked with <see cref="JsonIgnoreAttribute"/>.
+	/// </summary>
+	internal static IReadOnlyList<string> GetColumnNames<T>()
+		=> Cache.GetOrAdd(typeof(T), static type =>
+			type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+				.Where(p => p.CanRead && p.GetCustomAttribute<JsonIgnoreAttribute>() is null)
+				.Select(p => p.Name)
+				.ToList());
+}

--- a/code/Universe/Galaxy.cs
+++ b/code/Universe/Galaxy.cs
@@ -46,7 +46,7 @@ public abstract class Galaxy<T> : GalaxyBasic<T>, IGalaxy<T> where T : class, IC
     async Task<(Gravity g, IList<TS> T)> IGalaxy<T>.Paged<TS>(Q.Page page, IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> group)
         => await InternalPaged<TS>(page, clusters, columnOptions, sorting, group);
 
-    private async Task<(Gravity g, TArgType S)> InternalGet<TArgType>(IReadOnlyList<Cluster> clusters, IReadOnlyList<string> columns) where TArgType : ICosmicEntity
+    private async Task<(Gravity g, TArgType S)> InternalGet<TArgType>(IReadOnlyList<Cluster> clusters, IReadOnlyList<string> columns)
     {
         try
         {
@@ -63,7 +63,7 @@ public abstract class Galaxy<T> : GalaxyBasic<T>, IGalaxy<T> where T : class, IC
         }
     }
 
-    private async Task<(Gravity g, IList<TArgType> T)> InternalList<TArgType>(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> group) where TArgType : ICosmicEntity
+    private async Task<(Gravity g, IList<TArgType> T)> InternalList<TArgType>(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> group)
     {
         try
         {
@@ -76,7 +76,7 @@ public abstract class Galaxy<T> : GalaxyBasic<T>, IGalaxy<T> where T : class, IC
         }
     }
 
-    private async Task<(Gravity g, IList<TArgType> T)> InternalPaged<TArgType>(Q.Page page, IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> group) where TArgType : ICosmicEntity
+    private async Task<(Gravity g, IList<TArgType> T)> InternalPaged<TArgType>(Q.Page page, IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> group)
     {
         try
         {
@@ -117,7 +117,7 @@ public abstract class Galaxy<T> : GalaxyBasic<T>, IGalaxy<T> where T : class, IC
 
     QueryTuningRecommendations IGalaxy<T>.GetQueryRecommendations(string queryPattern, QueryType queryType) => QBuilder.GetQueryRecommendations(queryType);
 
-    private async Task<(Gravity g, IList<TArgType> T)> InternalListWithHints<TArgType>(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> group, QueryHints? hints) where TArgType : ICosmicEntity
+    private async Task<(Gravity g, IList<TArgType> T)> InternalListWithHints<TArgType>(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> group, QueryHints? hints)
     {
         try
         {

--- a/code/Universe/Interfaces/IGalaxy.cs
+++ b/code/Universe/Interfaces/IGalaxy.cs
@@ -14,7 +14,7 @@ public interface IGalaxy<T> : IGalaxyBasic<T> where T : ICosmicEntity
     /// <summary>
     /// Get one model from the database with a different type
     /// </summary>
-    Task<(Gravity g, TS S)> Get<TS>(IReadOnlyList<Cluster> clusters, IReadOnlyList<string> columns = null) where TS : ICosmicEntity;
+    Task<(Gravity g, TS S)> Get<TS>(IReadOnlyList<Cluster> clusters, IReadOnlyList<string> columns = null);
 
     /// <summary>
     /// Get list from the database with optional query optimization hints
@@ -24,7 +24,7 @@ public interface IGalaxy<T> : IGalaxyBasic<T> where T : ICosmicEntity
     /// <summary>
     /// Get list from the database with a different type
     /// </summary>
-    Task<(Gravity g, IList<TS> T)> List<TS>(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions = null, IReadOnlyList<Sorting.Option> sorting = null, IReadOnlyList<string> group = null, QueryHints? hints = null) where TS : ICosmicEntity;
+    Task<(Gravity g, IList<TS> T)> List<TS>(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions = null, IReadOnlyList<Sorting.Option> sorting = null, IReadOnlyList<string> group = null, QueryHints? hints = null);
 
     /// <summary>
     /// Get a paginated list from the database
@@ -34,7 +34,7 @@ public interface IGalaxy<T> : IGalaxyBasic<T> where T : ICosmicEntity
     /// <summary>
     /// Get a paginated list from the database
     /// </summary>
-    Task<(Gravity g, IList<TS> T)> Paged<TS>(Q.Page page, IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions = null, IReadOnlyList<Sorting.Option> sorting = null, IReadOnlyList<string> group = null) where TS : ICosmicEntity;
+    Task<(Gravity g, IList<TS> T)> Paged<TS>(Q.Page page, IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions = null, IReadOnlyList<Sorting.Option> sorting = null, IReadOnlyList<string> group = null);
 
     /// <summary>
     /// Generate SQL query without executing it

--- a/code/Universe/UniverseQuery.csproj
+++ b/code/Universe/UniverseQuery.csproj
@@ -21,7 +21,7 @@
 		<RepositoryType>Git</RepositoryType>
 		<Authors>norarrsgd</Authors>
 		<Product>Universe</Product>
-		<Version>3.3.1-preview.2</Version>
+		<Version>3.3.1-preview.3</Version>
 		<PackageReleaseNotes>
 			View release on
 			https://github.com/norarrsgd/universe/releases/tag/untagged-cdcf4202c2656450c07b

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -513,6 +513,14 @@
             <summary>Specify which columns to select.</summary>
             <remarks>Azure Cosmos DB column names are case-sensitive. When a naming policy is configured on <see cref="T:Universe.Builder.Options.UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.</remarks>
         </member>
+        <member name="M:Universe.Builder.Orbit`1.Select``1">
+            <summary>Specify which columns to select based on the public properties of a projection type.</summary>
+            <remarks>
+            Extracts all public instance property names from <typeparamref name="TProjection"/>, excluding properties marked with <see cref="T:System.Text.Json.Serialization.JsonIgnoreAttribute"/>.
+            When a naming policy is configured on <see cref="T:Universe.Builder.Options.UniverseSerializer"/>, column names are automatically transformed to match the serialized document field names.
+            This method is additive — it can be combined with <see cref="M:Universe.Builder.Orbit`1.Select(System.String[])"/> to include additional columns.
+            </remarks>
+        </member>
         <member name="M:Universe.Builder.Orbit`1.Distinct">
             <summary>Return only distinct results.</summary>
         </member>
@@ -1025,6 +1033,17 @@
         </member>
         <member name="M:Universe.Extensions.CosmicEntityExtensions.PartitionKeys(Universe.Interfaces.ICosmicEntity)">
             <summary>Builds the partition key values for the entity.</summary>
+        </member>
+        <member name="T:Universe.Extensions.ProjectionColumnExtractor">
+            <summary>
+            Extracts column names from a type's public properties for use with <see cref="M:Universe.Builder.Orbit`1.Select``1"/>.
+            Results are cached per type for performance.
+            </summary>
+        </member>
+        <member name="M:Universe.Extensions.ProjectionColumnExtractor.GetColumnNames``1">
+            <summary>
+            Returns the public instance property names for the given type, excluding properties marked with <see cref="T:System.Text.Json.Serialization.JsonIgnoreAttribute"/>.
+            </summary>
         </member>
         <member name="T:Universe.Extensions.StringExtensions">
             <summary>


### PR DESCRIPTION
## Summary
- Add `Select<TProjection>()` to Orbit that extracts column names from a type's public properties via cached reflection, excluding `[JsonIgnore]` properties
- Remove `ICosmicEntity` constraint from generic projection overloads (`ToListAsync<TS>()`, `GetAsync<TS>()`, `List<TS>()`, `Get<TS>()`, `Paged<TS>()`) — projection targets can now be any type (class, record, struct, record struct)
- Add `ProjectionColumnExtractor` utility with `ConcurrentDictionary` caching for per-type property name extraction
- Add 11 unit tests covering property extraction, `[JsonIgnore]` exclusion, inheritance, struct support, SQL equivalence, naming policy, and cache behavior
- Add Example16 demonstrating 6 real-world projection scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added type-safe Select<TProjection>() for projecting query results with automatic property extraction; respects [JsonIgnore], supports inheritance, record types, and structs, and combines additively with string-based selection.

* **Improvements**
  * Relaxed generic type constraints on several query methods for greater flexibility.

* **Tests**
  * Added comprehensive tests covering projection extraction, naming policy, combination rules, SQL equivalence, and caching.

* **Examples**
  * Added a demonstration showing various projection patterns.

* **Version**
  * Updated to 3.3.1-preview.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->