### PR TITLE
security: Harden query builder, exception handling, and storage permissions

### DIFF
--- a/code/DarkMatter/Examples/Example14_SQLInjectionProtection.cs
+++ b/code/DarkMatter/Examples/Example14_SQLInjectionProtection.cs
@@ -51,6 +51,9 @@ public class Example14_SqlInjectionProtection(IGalaxy<MyObject> galaxy) : Exampl
         // Test 9: Attempt to inject through FTScore value (multi-rank RRF)
         await TestFTScoreMultiRankInjection();
 
+        // Test 10: Attempt to inject through WithWeights weight value
+        await TestWeightValueInjection();
+
         Console.WriteLine($"Total RU Used: {ruUsed}\n");
         return ruUsed;
     }
@@ -293,6 +296,41 @@ public class Example14_SqlInjectionProtection(IGalaxy<MyObject> galaxy) : Exampl
         catch (CosmosException)
         {
             Console.WriteLine("Query executed safely (CosmosException from server, but SQL was parameterized).\n");
+        }
+    }
+
+    private async Task TestWeightValueInjection()
+    {
+        Console.WriteLine("--- Test 10: Weight Value Injection Attempt ---");
+        Console.WriteLine("Attempting to inject SQL through weight value: \"0.7], COUNT(*) AS total --\"\n");
+
+        try
+        {
+            // Construct a sorting option with WEIGHTED direction and a malicious weight value.
+            // This simulates what Orbit.WithWeights() produces internally.
+            Sorting.Option maliciousWeight = new("0.7], COUNT(*) AS total --", Sorting.Direction.WEIGHTED);
+
+            // SanitizeInputs validates weight values before any query execution or Cosmos DB call
+            _ = await galaxy.List(
+                clusters:
+                [
+                    new(Catalysts:
+                    [
+                        new(nameof(MyObject.Name), new[] { "test" }, Operator: Q.Operator.FTScore),
+                        new(nameof(MyObject.Name), new[] { "test2" }, Operator: Q.Operator.FTScore)
+                    ])
+                ],
+                columnOptions: new(
+                    Top: 10,
+                    Names: [nameof(MyObject.Name)]
+                ),
+                sorting: [maliciousWeight]
+            );
+            Console.WriteLine("FAILED: Injection was not blocked!\n");
+        }
+        catch (UniverseException ex)
+        {
+            Console.WriteLine($"BLOCKED: {ex.Message}\n");
         }
     }
 

--- a/code/Universe/Builder/Options/Parameters.cs
+++ b/code/Universe/Builder/Options/Parameters.cs
@@ -63,6 +63,8 @@ public readonly record struct Catalyst(
         {
             if (Value is not float[] vector || vector.Length == 0)
                 violations.Add("Value must be a non-empty array of floats for VectorDistance operator");
+            else if (vector.Length > 8192)
+                violations.Add("Vector dimension exceeds maximum allowed size of 8192 for VectorDistance operator");
             else if (vector.Any(v => float.IsNaN(v) || float.IsInfinity(v)))
                 violations.Add("All elements in the vector must be finite numbers for VectorDistance operator");
         }

--- a/code/Universe/Builder/Options/Parameters.cs
+++ b/code/Universe/Builder/Options/Parameters.cs
@@ -63,8 +63,8 @@ public readonly record struct Catalyst(
         {
             if (Value is not float[] vector || vector.Length == 0)
                 violations.Add("Value must be a non-empty array of floats for VectorDistance operator");
-            else if (vector.Length > 8192)
-                violations.Add("Vector dimension exceeds maximum allowed size of 8192 for VectorDistance operator");
+            else if (vector.Length > 4096)
+                violations.Add("Vector dimension exceeds maximum allowed size of 4096 for VectorDistance operator");
             else if (vector.Any(v => float.IsNaN(v) || float.IsInfinity(v)))
                 violations.Add("All elements in the vector must be finite numbers for VectorDistance operator");
         }

--- a/code/Universe/Builder/QueryBuilder.cs
+++ b/code/Universe/Builder/QueryBuilder.cs
@@ -479,12 +479,15 @@ internal class UniverseBuilder : IDisposable
         }
 
         // Validate each segment is a parseable number
-        string[] segments = inner.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        string[] segments = inner.Split(',', StringSplitOptions.TrimEntries);
         if (segments.Length == 0)
             throw new UniverseException("Weight value must contain at least one numeric value.");
 
         foreach (string segment in segments)
         {
+            if (string.IsNullOrWhiteSpace(segment))
+                throw new UniverseException("Weight value contains an empty segment.");
+
             if (!double.TryParse(segment, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out _))
                 throw new UniverseException($"Weight value '{segment}' is not a valid number.");
         }

--- a/code/Universe/Builder/QueryBuilder.cs
+++ b/code/Universe/Builder/QueryBuilder.cs
@@ -401,10 +401,9 @@ internal class UniverseBuilder : IDisposable
         {
             foreach (Sorting.Option sort in sorting)
             {
-                // Skip validation for weight values that are already bracket-wrapped like [FieldName]
-                // or WEIGHTED direction columns (used in ORDER BY RANK), as these are intentionally
-                // formatted for ORDER BY RANK and not raw user identifiers
-                if (sort.Direction is not Sorting.Direction.WEIGHTED)
+                if (sort.Direction is Sorting.Direction.WEIGHTED)
+                    ValidateWeightValue(sort.Column);
+                else
                     ValidateIdentifier(sort.Column, "Sorting.Column");
             }
         }
@@ -451,6 +450,44 @@ internal class UniverseBuilder : IDisposable
         // Reject control characters which could lead to query corruption
         if (identifier.Any(char.IsControl))
             throw new UniverseException($"{parameterName} contains control characters.");
+    }
+
+    /// <summary>
+    /// Validates that a weight value for ORDER BY RANK RRF contains only safe numeric content.
+    /// Weight values should be comma-separated decimal numbers, optionally bracket-wrapped (e.g., "0.7, 0.3").
+    /// </summary>
+    private static void ValidateWeightValue(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new UniverseException("Weight value cannot be null or empty.");
+
+        // Strip optional surrounding brackets for validation
+        string inner = value.Trim();
+        if (inner.StartsWith('['))
+            inner = inner[1..];
+        if (inner.EndsWith(']'))
+            inner = inner[..^1];
+
+        if (string.IsNullOrWhiteSpace(inner))
+            throw new UniverseException("Weight value cannot be empty.");
+
+        // Defense-in-depth: reject invalid characters before parsing individual segments
+        foreach (char c in inner)
+        {
+            if (!char.IsDigit(c) && c != '.' && c != ',' && !char.IsWhiteSpace(c))
+                throw new UniverseException($"Weight value contains invalid character '{c}'. Only numeric values separated by commas are allowed.");
+        }
+
+        // Validate each segment is a parseable number
+        string[] segments = inner.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0)
+            throw new UniverseException("Weight value must contain at least one numeric value.");
+
+        foreach (string segment in segments)
+        {
+            if (!double.TryParse(segment, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out _))
+                throw new UniverseException($"Weight value '{segment}' is not a valid number.");
+        }
     }
 
     private string ConvertName(string name) => _namingPolicy?.ConvertName(name) ?? name;

--- a/code/Universe/Builder/Strategies/QueryTuner.cs
+++ b/code/Universe/Builder/Strategies/QueryTuner.cs
@@ -92,7 +92,7 @@ internal sealed partial class QueryTuner : IDisposable
         {
             await _storage.SaveAsync(stats);
         }
-        catch (SystemException ex)
+        catch (System.Exception ex) when (ex is IOException or InvalidOperationException)
         {
             Trace.TraceWarning($"[UniverseQuery] Failed to persist query statistics: {ex.Message}");
         }
@@ -274,7 +274,7 @@ internal sealed partial class QueryTuner : IDisposable
                 Interlocked.Increment(ref _totalCount);
             }
         }
-        catch (SystemException ex)
+        catch (System.Exception ex) when (ex is IOException or InvalidOperationException)
         {
             Trace.TraceWarning($"[UniverseQuery] Failed to load persisted statistics: {ex.Message}");
         }

--- a/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
+++ b/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
@@ -84,6 +84,10 @@ public sealed class FileStatisticsStorage : IQueryStatisticsStorage, IDisposable
         {
             Trace.TraceWarning($"[UniverseQuery] File statistics save failed: {ex.Message}");
         }
+        catch (UnauthorizedAccessException ex)
+        {
+            Trace.TraceWarning($"[UniverseQuery] File statistics save failed (access denied): {ex.Message}");
+        }
         finally
         {
             _lock.Release();

--- a/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
+++ b/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
@@ -75,6 +75,7 @@ public sealed class FileStatisticsStorage : IQueryStatisticsStorage, IDisposable
             string json = JsonSerializer.Serialize(toSave, JsonOptions);
 
             await File.WriteAllTextAsync(_filePath, json);
+            PlatformDetection.SetRestrictivePermissions(_filePath);
         }
         catch (JsonException ex)
         {

--- a/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
+++ b/code/Universe/Builder/Strategies/Storage/FileStatisticsStorage.cs
@@ -28,10 +28,13 @@ public sealed class FileStatisticsStorage : IQueryStatisticsStorage, IDisposable
     {
         _filePath = PlatformDetection.ValidateStoragePath(filePath ?? ResolveDefaultPath());
 
-        // Ensure directory exists
+        // Ensure directory exists with restrictive permissions
         string directory = Path.GetDirectoryName(_filePath)!;
         if (!Directory.Exists(directory))
+        {
             Directory.CreateDirectory(directory);
+            PlatformDetection.SetRestrictivePermissions(directory);
+        }
     }
 
     /// <summary>
@@ -77,7 +80,7 @@ public sealed class FileStatisticsStorage : IQueryStatisticsStorage, IDisposable
         {
             Trace.TraceWarning($"[UniverseQuery] File statistics serialization failed: {ex.Message}");
         }
-        catch (SystemException ex)
+        catch (IOException ex)
         {
             Trace.TraceWarning($"[UniverseQuery] File statistics save failed: {ex.Message}");
         }
@@ -158,9 +161,9 @@ public sealed class FileStatisticsStorage : IQueryStatisticsStorage, IDisposable
             return JsonSerializer.Deserialize<List<QueryExecutionStatistics>>(json)
                    ?? [];
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            // If file is corrupted, return empty list
+            Trace.TraceWarning($"[UniverseQuery] Statistics file may be corrupted or tampered with ({_filePath}): {ex.Message}");
             return [];
         }
     }

--- a/code/Universe/Builder/Strategies/Storage/PlatformDetection.cs
+++ b/code/Universe/Builder/Strategies/Storage/PlatformDetection.cs
@@ -82,7 +82,7 @@ internal static class PlatformDetection
             else if (File.Exists(path))
                 File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
         }
-        catch (IOException ex)
+        catch (System.Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
         {
             System.Diagnostics.Trace.TraceWarning($"[UniverseQuery] Failed to set file permissions: {ex.Message}");
         }

--- a/code/Universe/Builder/Strategies/Storage/PlatformDetection.cs
+++ b/code/Universe/Builder/Strategies/Storage/PlatformDetection.cs
@@ -65,4 +65,26 @@ internal static class PlatformDetection
 
         return fullPath;
     }
+
+    /// <summary>
+    /// Sets restrictive permissions (owner-only) on Unix-like systems to prevent other users from reading statistics.
+    /// No-op on Windows where NTFS ACLs are used instead.
+    /// </summary>
+    internal static void SetRestrictivePermissions(string path)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+            return;
+
+        try
+        {
+            if (Directory.Exists(path))
+                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            else if (File.Exists(path))
+                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        catch (IOException ex)
+        {
+            System.Diagnostics.Trace.TraceWarning($"[UniverseQuery] Failed to set file permissions: {ex.Message}");
+        }
+    }
 }

--- a/code/Universe/Builder/Strategies/Storage/SqliteStatisticsStorage.cs
+++ b/code/Universe/Builder/Strategies/Storage/SqliteStatisticsStorage.cs
@@ -63,10 +63,13 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
         _batchSize = batchSize;
         _flushInterval = TimeSpan.FromSeconds(flushIntervalSeconds);
 
-        // Ensure directory exists
+        // Ensure directory exists with restrictive permissions
         string directory = Path.GetDirectoryName(_dbPath);
         if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
             Directory.CreateDirectory(directory);
+            PlatformDetection.SetRestrictivePermissions(directory);
+        }
 
         // Create connection with WAL mode for better concurrency
         SqliteConnectionStringBuilder connectionBuilder = new()
@@ -143,7 +146,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
             if (result != "ok")
                 Trace.TraceWarning($"[UniverseQuery] SQLite integrity check failed: {result}");
         }
-        catch (SystemException ex)
+        catch (SqliteException ex)
         {
             Trace.TraceWarning($"[UniverseQuery] SQLite integrity check error: {ex.Message}");
         }
@@ -363,7 +366,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
                 {
                     hints = JsonSerializer.Deserialize<Dictionary<string, object>>(hintsJson);
                 }
-                catch (SystemException ex)
+                catch (JsonException ex)
                 {
                     Trace.TraceWarning($"[UniverseQuery] Failed to deserialize query hints: {ex.Message}");
                 }
@@ -437,7 +440,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
             foreach (QueryExecutionStatistics stat in toWrite)
                 _retryCounts.TryRemove(stat, out _);
         }
-        catch (SystemException ex)
+        catch (System.Exception ex) when (ex is SqliteException or IOException)
         {
             Trace.TraceWarning($"[UniverseQuery] SQLite flush failed: {ex.Message}");
             RequeueWithRetryLimit(toWrite);
@@ -480,7 +483,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
         {
             await action();
         }
-        catch (SystemException ex)
+        catch (System.Exception ex) when (ex is SqliteException or IOException or TimeoutException)
         {
             Trace.TraceWarning($"[UniverseQuery] Background operation failed: {ex.Message}");
         }
@@ -504,7 +507,7 @@ public sealed class SqliteStatisticsStorage : IQueryStatisticsStorage, IDisposab
         {
             FlushAsync().Wait(TimeSpan.FromSeconds(10));
         }
-        catch (SystemException ex)
+        catch (System.Exception ex) when (ex is SqliteException or IOException or TimeoutException or AggregateException)
         {
             Trace.TraceWarning($"[UniverseQuery] Final flush during dispose failed: {ex.Message}");
         }

--- a/code/Universe/Extensions/HintValueExtensions.cs
+++ b/code/Universe/Extensions/HintValueExtensions.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Universe.Exception;
 
 namespace Universe.Extensions;
 
@@ -7,15 +8,26 @@ namespace Universe.Extensions;
 /// </summary>
 internal static class HintValueExtensions
 {
+    private const int MaxHintIntValue = 10_000;
+
     /// <summary>
-    /// Converts an object to int, handling both JsonElement (from deserialized JSON) and primitive types
+    /// Converts an object to int, handling both JsonElement (from deserialized JSON) and primitive types.
+    /// Values are clamped to [0, 10000] to prevent unreasonable query option settings.
     /// </summary>
     public static int ToInt(this object value)
     {
-        if (value is JsonElement jsonElement)
-            return jsonElement.GetInt32();
+        try
+        {
+            int result = value is JsonElement jsonElement
+                ? jsonElement.GetInt32()
+                : Convert.ToInt32(value);
 
-        return Convert.ToInt32(value);
+            return Math.Clamp(result, 0, MaxHintIntValue);
+        }
+        catch (System.Exception ex) when (ex is FormatException or OverflowException or InvalidOperationException)
+        {
+            throw new UniverseException($"Hint value '{value}' is not a valid integer.", ex);
+        }
     }
 
     /// <summary>
@@ -23,9 +35,15 @@ internal static class HintValueExtensions
     /// </summary>
     public static bool ToBool(this object value)
     {
-        if (value is JsonElement jsonElement)
-            return jsonElement.GetBoolean();
-
-        return Convert.ToBoolean(value);
+        try
+        {
+            return value is JsonElement jsonElement
+                ? jsonElement.GetBoolean()
+                : Convert.ToBoolean(value);
+        }
+        catch (System.Exception ex) when (ex is FormatException or InvalidOperationException)
+        {
+            throw new UniverseException($"Hint value '{value}' is not a valid boolean.", ex);
+        }
     }
 }

--- a/code/Universe/GalaxyBasic.cs
+++ b/code/Universe/GalaxyBasic.cs
@@ -106,12 +106,12 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
                 tasks.Add(batch.ExecuteAsync().ContinueWith(t =>
                 {
                     if (!t.IsCompletedSuccessfully)
-                        throw new UniverseException(t.Exception?.Flatten().InnerException?.Message ?? "Oops! Something went wrong!");
+                        throw new UniverseException("Bulk create batch operation failed.", t.Exception?.Flatten().InnerException);
 
                     if (t.Result.IsSuccessStatusCode)
                         return t.Result.RequestCharge;
                     else
-                        throw new UniverseException($"Transaction batch failed with status code {t.Result.StatusCode}. Message: {t.Result.ErrorMessage}");
+                        throw new UniverseException($"Transaction batch failed with status code {t.Result.StatusCode}.");
                 }));
             }
 
@@ -183,12 +183,12 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
                 tasks.Add(batch.ExecuteAsync().ContinueWith(t =>
                 {
                     if (!t.IsCompletedSuccessfully)
-                        throw new UniverseException(t.Exception?.Flatten().InnerException?.Message ?? "Oops! Something went wrong!");
+                        throw new UniverseException("Bulk modify batch operation failed.", t.Exception?.Flatten().InnerException);
 
                     if (t.Result.IsSuccessStatusCode)
                         return t.Result.RequestCharge;
                     else
-                        throw new UniverseException($"Transaction batch failed with status code {t.Result.StatusCode}. Message: {t.Result.ErrorMessage}");
+                        throw new UniverseException($"Transaction batch failed with status code {t.Result.StatusCode}.");
                 }));
             }
 
@@ -199,7 +199,7 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
-            throw new UniverseException($"Something went wrong doing the bulk operation. See error: {ex.Message}");
+            throw new UniverseException("Bulk modify operation failed.", ex);
         }
         catch (CosmosException ex) when (ex.StatusCode != HttpStatusCode.NotFound)
         {

--- a/code/Universe/GalaxyCore.cs
+++ b/code/Universe/GalaxyCore.cs
@@ -13,7 +13,13 @@ public abstract class GalaxyCore : IDisposable
     internal readonly bool _allowBulk;
     internal readonly JsonNamingPolicy _namingPolicy;
 
-    /// <summary></summary>
+    /// <summary>
+    /// Initialize Galaxy core with Cosmos DB connection.
+    /// </summary>
+    /// <remarks>
+    /// WARNING: Setting <paramref name="recordQueries"/> to <c>true</c> includes full query text and parameter values
+    /// in Gravity responses. This may expose sensitive data (PII, filter values). Use only for debugging — never enable in production.
+    /// </remarks>
     protected GalaxyCore(CosmosClient client, string database, string container, IReadOnlyList<string> partitionKey, bool recordQueries = false)
     {
         if (string.IsNullOrWhiteSpace(container))

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -576,6 +576,12 @@
         <member name="M:Universe.Builder.Orbit`1.GenerateQuery">
             <summary>Generate the SQL query without executing it.</summary>
         </member>
+        <member name="M:Universe.Builder.UniverseBuilder.ValidateWeightValue(System.String)">
+            <summary>
+            Validates that a weight value for ORDER BY RANK RRF contains only safe numeric content.
+            Weight values should be comma-separated decimal numbers, optionally bracket-wrapped (e.g., "0.7, 0.3").
+            </summary>
+        </member>
         <member name="T:Universe.Builder.Strategies.DirectQueryStrategy">
             <summary>
             Direct execution strategy for simple queries
@@ -911,6 +917,12 @@
             Thrown when the path is empty, contains null bytes, or cannot be resolved to a rooted path.
             </exception>
         </member>
+        <member name="M:Universe.Builder.Strategies.Storage.PlatformDetection.SetRestrictivePermissions(System.String)">
+            <summary>
+            Sets restrictive permissions (owner-only) on Unix-like systems to prevent other users from reading statistics.
+            No-op on Windows where NTFS ACLs are used instead.
+            </summary>
+        </member>
         <member name="T:Universe.Builder.Strategies.Storage.SqliteStatisticsStorage">
             <summary>
             SQLite-based storage for query statistics with high-performance features:
@@ -1003,7 +1015,8 @@
         </member>
         <member name="M:Universe.Extensions.HintValueExtensions.ToInt(System.Object)">
             <summary>
-            Converts an object to int, handling both JsonElement (from deserialized JSON) and primitive types
+            Converts an object to int, handling both JsonElement (from deserialized JSON) and primitive types.
+            Values are clamped to [0, 10000] to prevent unreasonable query option settings.
             </summary>
         </member>
         <member name="M:Universe.Extensions.HintValueExtensions.ToBool(System.Object)">
@@ -1088,7 +1101,13 @@
             </summary>
         </member>
         <member name="M:Universe.GalaxyCore.#ctor(Microsoft.Azure.Cosmos.CosmosClient,System.String,System.String,System.Collections.Generic.IReadOnlyList{System.String},System.Boolean)">
-            <summary></summary>
+            <summary>
+            Initialize Galaxy core with Cosmos DB connection.
+            </summary>
+            <remarks>
+            WARNING: Setting <paramref name="recordQueries"/> to <c>true</c> includes full query text and parameter values
+            in Gravity responses. This may expose sensitive data (PII, filter values). Use only for debugging — never enable in production.
+            </remarks>
         </member>
         <member name="M:Universe.GalaxyCore.Dispose(System.Boolean)">
             <summary></summary>


### PR DESCRIPTION
## Summary
- Fix critical SQL injection vulnerability in `WithWeights()` by adding `ValidateWeightValue()` that restricts input to numeric content only
- Sanitize exception messages in bulk create/modify operations to prevent Cosmos DB error detail leakage
- Add bounds checking and clamping to `HintValueExtensions` to prevent DoS via malformed query hints
- Narrow broad `SystemException` catching to specific types (`SqliteException`, `IOException`, `JsonException`) across storage and tuner code
- Set restrictive file permissions (owner-only) on statistics storage directories via shared `PlatformDetection.SetRestrictivePermissions()`
- Add vector dimension cap (8192), `recordQueries` PII warning, and WithWeights injection test in Example14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Bug Fixes**
  * Added SQL injection protection for weighted sort parameters and weight-value validation
  * Enforced vector size limit (max 4096 elements)
  * Applied restrictive filesystem permissions for storage directories and files
  * Clamped hint integer values to 0–10,000
  * Improved robustness, logging, and error handling for persisted statistics and storage operations

* **Documentation**
  * Added warning about sensitive-data exposure when query recording is enabled and documented weight/permission behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->