### PR TITLE
nuget: upgrade dependencies

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-<Version>3.4.1-preview.2</Version>
+<Version>3.4.1-preview.3</Version>

--- a/code/Universe.Tests/Storage/FileStatisticsStorageTests.cs
+++ b/code/Universe.Tests/Storage/FileStatisticsStorageTests.cs
@@ -3,7 +3,6 @@ using Universe.Builder.Strategies;
 using Universe.Builder.Strategies.Storage;
 using Universe.Tests.Helpers;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Universe.Tests.Storage;
 
@@ -95,7 +94,7 @@ public sealed class FileStatisticsStorageTests : IDisposable
     public async Task CorruptJson_RecoversGracefully()
     {
         // Write corrupt JSON directly to the file
-        await File.WriteAllTextAsync(_filePath, "{ this is not valid json [[[");
+        await File.WriteAllTextAsync(_filePath, "{ this is not valid json [[[", TestContext.Current.CancellationToken);
 
         // LoadRecentAsync should return empty (not throw)
         IList<QueryExecutionStatistics> loaded = await _storage.LoadRecentAsync(10);

--- a/code/Universe.Tests/Storage/SqliteStatisticsStorageTests.cs
+++ b/code/Universe.Tests/Storage/SqliteStatisticsStorageTests.cs
@@ -24,9 +24,28 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
 
     private static void TryDeleteFiles(string dbPath)
     {
-        foreach (string suffix in new[] { "", "-wal", "-shm" })
+        string fullPath = Path.GetFullPath(dbPath);
+        string baseDirectory = Path.GetFullPath(AppContext.BaseDirectory);
+
+        string relativePath = Path.GetRelativePath(baseDirectory, fullPath);
+        if (Path.IsPathRooted(relativePath) || relativePath == ".." || relativePath.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            throw new InvalidOperationException("Test cleanup path must stay under the test output directory.");
+
+        string directory = Path.GetDirectoryName(fullPath)!;
+        string fileName = Path.GetFileName(fullPath);
+        HashSet<string> allowedNames = new HashSet<string>(StringComparer.Ordinal)
         {
-            try { if (File.Exists(dbPath + suffix)) File.Delete(dbPath + suffix); }
+            fileName,
+            fileName + "-wal",
+            fileName + "-shm"
+        };
+
+        foreach (FileInfo file in new DirectoryInfo(directory).EnumerateFiles(fileName + "*"))
+        {
+            if (!allowedNames.Contains(file.Name))
+                continue;
+
+            try { file.Delete(); }
             catch { /* best effort cleanup */ }
         }
     }

--- a/code/Universe.Tests/Storage/SqliteStatisticsStorageTests.cs
+++ b/code/Universe.Tests/Storage/SqliteStatisticsStorageTests.cs
@@ -154,7 +154,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
             await storage.SaveAsync(TestStatisticsFactory.Create(queryHash: $"batch-{i}"));
 
         // Allow fire-and-forget flush triggered at batchSize threshold
-        await Task.Delay(500);
+        await Task.Delay(500, TestContext.Current.CancellationToken);
 
         IList<QueryExecutionStatistics> loaded = await storage.LoadRecentAsync(100);
         Assert.Equal(5, loaded.Count);
@@ -174,7 +174,7 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
             await storage.SaveAsync(TestStatisticsFactory.Create(queryHash: $"timer-{i}"));
 
         // Wait for timer-based flush (1 second interval)
-        await Task.Delay(2000);
+        await Task.Delay(2000, TestContext.Current.CancellationToken);
 
         IList<QueryExecutionStatistics> loaded = await storage.LoadRecentAsync(100);
         Assert.Equal(3, loaded.Count);
@@ -345,22 +345,23 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
         string dbPath = Path.Combine(AppContext.BaseDirectory, $"test-dl-{Guid.NewGuid()}.db");
         using SqliteStatisticsStorage storage = new SqliteStatisticsStorage(dbPath, batchSize: 2, flushIntervalSeconds: 1);
 
-        using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
 
         Task saveTask = Task.Run(async () =>
         {
             for (int i = 0; i < 50 && !cts.IsCancellationRequested; i++)
                 await storage.SaveAsync(TestStatisticsFactory.Create(queryHash: $"dl-{i}"));
-        });
+        }, cts.Token);
 
         Task loadTask = Task.Run(async () =>
         {
             for (int i = 0; i < 10 && !cts.IsCancellationRequested; i++)
             {
                 await storage.LoadRecentAsync(10);
-                await Task.Delay(50);
+                await Task.Delay(50, cts.Token);
             }
-        });
+        }, cts.Token);
 
         // If we reach here without timeout, no deadlock occurred
         await Task.WhenAll(saveTask, loadTask);

--- a/code/Universe.Tests/Storage/SqliteStatisticsStorageTests.cs
+++ b/code/Universe.Tests/Storage/SqliteStatisticsStorageTests.cs
@@ -33,6 +33,9 @@ public sealed class SqliteStatisticsStorageTests : IDisposable
 
         string directory = Path.GetDirectoryName(fullPath)!;
         string fileName = Path.GetFileName(fullPath);
+        if (!Directory.Exists(directory))
+            return;
+
         HashSet<string> allowedNames = new HashSet<string>(StringComparer.Ordinal)
         {
             fileName,

--- a/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
@@ -243,9 +243,28 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
 
     private static void TryDeleteFiles(string dbPath)
     {
-        foreach (string suffix in new[] { "", "-wal", "-shm" })
+        string fullPath = Path.GetFullPath(dbPath);
+        string baseDirectory = Path.GetFullPath(AppContext.BaseDirectory);
+
+        string relativePath = Path.GetRelativePath(baseDirectory, fullPath);
+        if (Path.IsPathRooted(relativePath) || relativePath == ".." || relativePath.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            throw new InvalidOperationException("Test cleanup path must stay under the test output directory.");
+
+        string directory = Path.GetDirectoryName(fullPath)!;
+        string fileName = Path.GetFileName(fullPath);
+        HashSet<string> allowedNames = new HashSet<string>(StringComparer.Ordinal)
         {
-            try { if (File.Exists(dbPath + suffix)) File.Delete(dbPath + suffix); }
+            fileName,
+            fileName + "-wal",
+            fileName + "-shm"
+        };
+
+        foreach (FileInfo file in new DirectoryInfo(directory).EnumerateFiles(fileName + "*"))
+        {
+            if (!allowedNames.Contains(file.Name))
+                continue;
+
+            try { file.Delete(); }
             catch { /* best effort cleanup */ }
         }
     }

--- a/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
@@ -3,7 +3,6 @@ using Universe.Builder.Strategies;
 using Universe.Builder.Strategies.Storage;
 using Universe.Tests.Helpers;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Universe.Tests.Tuner;
 
@@ -206,7 +205,7 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
         // Measure InMemory startup
         Stopwatch sw = Stopwatch.StartNew();
         using QueryTuner inMemoryTuner = new QueryTuner();
-        await Task.Delay(100); // Give async loading a chance
+        await Task.Delay(100, TestContext.Current.CancellationToken); // Give async loading a chance
         QueryTuningRecommendations inMemoryRec = inMemoryTuner.GetRecommendations(QueryType.Simple);
         sw.Stop();
         TimeSpan inMemoryTime = sw.Elapsed;
@@ -225,7 +224,7 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
             {
                 sqliteRec = sqliteTuner.GetRecommendations(QueryType.Simple);
                 if (sqliteRec.IsDataDriven) break;
-                await Task.Delay(100);
+                await Task.Delay(100, TestContext.Current.CancellationToken);
             }
             sw.Stop();
             sqliteTime = sw.Elapsed;

--- a/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerPerformanceTests.cs
@@ -252,6 +252,9 @@ public sealed class QueryTunerPerformanceTests(ITestOutputHelper output)
 
         string directory = Path.GetDirectoryName(fullPath)!;
         string fileName = Path.GetFileName(fullPath);
+        if (!Directory.Exists(directory))
+            return;
+
         HashSet<string> allowedNames = new HashSet<string>(StringComparer.Ordinal)
         {
             fileName,

--- a/code/Universe.Tests/Tuner/QueryTunerTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerTests.cs
@@ -360,7 +360,7 @@ public sealed class QueryTunerTests
         {
             rec = tuner.GetRecommendations(QueryType.Simple);
             if (rec.IsDataDriven) break;
-            await Task.Delay(100);
+            await Task.Delay(100, TestContext.Current.CancellationToken);
         }
 
         Assert.True(rec.IsDataDriven,

--- a/code/Universe.Tests/Tuner/QueryTunerTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerTests.cs
@@ -411,6 +411,9 @@ public sealed class QueryTunerTests
 
         string directory = Path.GetDirectoryName(fullPath)!;
         string fileName = Path.GetFileName(fullPath);
+        if (!Directory.Exists(directory))
+            return;
+
         HashSet<string> allowedNames = new HashSet<string>(StringComparer.Ordinal)
         {
             fileName,

--- a/code/Universe.Tests/Tuner/QueryTunerTests.cs
+++ b/code/Universe.Tests/Tuner/QueryTunerTests.cs
@@ -402,9 +402,28 @@ public sealed class QueryTunerTests
 
     private static void TryDeleteFiles(string dbPath)
     {
-        foreach (string suffix in new[] { "", "-wal", "-shm" })
+        string fullPath = Path.GetFullPath(dbPath);
+        string baseDirectory = Path.GetFullPath(AppContext.BaseDirectory);
+
+        string relativePath = Path.GetRelativePath(baseDirectory, fullPath);
+        if (Path.IsPathRooted(relativePath) || relativePath == ".." || relativePath.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            throw new InvalidOperationException("Test cleanup path must stay under the test output directory.");
+
+        string directory = Path.GetDirectoryName(fullPath)!;
+        string fileName = Path.GetFileName(fullPath);
+        HashSet<string> allowedNames = new HashSet<string>(StringComparer.Ordinal)
         {
-            try { if (File.Exists(dbPath + suffix)) File.Delete(dbPath + suffix); }
+            fileName,
+            fileName + "-wal",
+            fileName + "-shm"
+        };
+
+        foreach (FileInfo file in new DirectoryInfo(directory).EnumerateFiles(fileName + "*"))
+        {
+            if (!allowedNames.Contains(file.Name))
+                continue;
+
+            try { file.Delete(); }
             catch { /* best effort cleanup */ }
         }
     }

--- a/code/Universe.Tests/Universe.Tests.csproj
+++ b/code/Universe.Tests/Universe.Tests.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
+		<OutputType>Exe</OutputType>
 		<Nullable>disable</Nullable>
 		<LangVersion>14.0</LangVersion>
 		<IsPackable>false</IsPackable>
@@ -10,8 +11,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+		<PackageReference Include="xunit.v3" Version="3.2.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/code/Universe/UniverseQuery.csproj
+++ b/code/Universe/UniverseQuery.csproj
@@ -21,7 +21,7 @@
 		<RepositoryType>Git</RepositoryType>
 		<Authors>norarrsgd</Authors>
 		<Product>Universe</Product>
-		<Version>3.4.1-preview.2</Version>
+		<Version>3.4.1-preview.3</Version>
 		<PackageReleaseNotes>
 			View release on
 			https://github.com/norarrsgd/universe/releases/tag/untagged-cdcf4202c2656450c07b

--- a/code/Universe/UniverseQuery.csproj
+++ b/code/Universe/UniverseQuery.csproj
@@ -44,8 +44,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.60.0" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Summary
- Upgrade Cosmos, SQLite, and .NET test dependencies to current stable versions.
- Migrate the test project from xUnit v2 to xUnit v3 with executable test-project configuration.
- Update affected async tests and cleanup helpers for xUnit v3 cancellation and path-cleanup safety.
- Bump the package prerelease version to 3.4.1-preview.3.