### PR TITLE
fix: Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -6,6 +6,9 @@ on:
       - 'prod'
       - 'beta'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Build, Pack & Publish NuGet


### PR DESCRIPTION
Potential fix for [https://github.com/norarrsgd/universe/security/code-scanning/4](https://github.com/norarrsgd/universe/security/code-scanning/4)

Add an explicit `permissions` block in `.github/workflows/nuget-publish.yml` at the workflow root (best here since there is one job, and this documents policy globally). Set:
- `contents: read`

This is the least-privilege setting needed for `actions/checkout`. No other permissions are required based on the shown steps, because publishing to NuGet uses `secrets.NUGET_KEY`, not GitHub package publishing.

Edit region: directly after the `on:` trigger block (before `jobs:`), or alternatively under `jobs.publish`. Root-level is the cleanest single change without altering functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration with explicit permissions declaration for improved security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->