### PR TITLE
feature: add optional document cache

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -1,5 +1,6 @@
 on: push
 name: dotnet-ci
+
 permissions:
   contents: read
 

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -5,6 +5,9 @@ on:
       - dev
       - prod
 
+permissions:
+  contents: read
+
 jobs:
   semgrep:
     name: Semgrep Scan

--- a/.github/workflows/semgrep-pr-ci.yml
+++ b/.github/workflows/semgrep-pr-ci.yml
@@ -1,6 +1,9 @@
 name: Semgrep
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   semgrep:
     name: Semgrep PR Scan

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -54,11 +54,13 @@ code/
 |   |-- GalaxyBasic.cs
 |   |-- Galaxy.cs
 |   |-- GalaxyProcedures.cs
+|   |-- DocumentCacheOptions.cs
 |   |-- UniverseOptions.cs
 |   |-- Builder/
 |   |   |-- QueryBuilder.cs
 |   |   |-- Orbit.cs
 |   |   |-- ClusterBuilder.cs
+|   |   |-- Caching/
 |   |   |-- Options/
 |   |   `-- Strategies/
 |   |-- Interfaces/
@@ -138,6 +140,7 @@ code/Universe/
 |-- GalaxyBasic.cs
 |-- GalaxyCore.cs
 |-- GalaxyProcedures.cs
+|-- DocumentCacheOptions.cs
 |-- UniverseOptions.cs
 |-- UniverseQuery.csproj
 |-- UniverseQuery.xml
@@ -148,6 +151,7 @@ code/Universe/
 File responsibilities:
 
 - `Attributes/PartitionKeyAttribute.cs`: attribute for marking partition-key properties. It supports default sequence `1`, validates sequence `1` through `3`, and optionally accepts an explicit Cosmos key name.
+- `Builder/Caching/DocumentCache.cs`: optional process-local document cache used only when `UniverseOptions.WithDocumentCache(...)` is configured.
 - `Builder/ClusterBuilder.cs`: fluent builder for one `Cluster`. It stores catalysts in order and tracks the next intra-cluster `AND` / `OR` connector.
 - `Builder/Orbit.cs`: public fluent query builder. It accumulates clusters, selected columns, sort options, aggregates, group-by columns, pagination, joins, hints, and execution mode.
 - `Builder/QueryBuilder.cs`: internal SQL-generation and query-dispatch core. Treat as security-sensitive.
@@ -185,9 +189,10 @@ File responsibilities:
 - `GalaxyBasic.cs`: basic document operations and bulk transaction batch operations.
 - `Galaxy.cs`: advanced query operations and generated-query inspection.
 - `GalaxyProcedures.cs`: stored procedure operations.
+- `DocumentCacheOptions.cs`: opt-in document-cache configuration and cache ownership.
 - `Interfaces/*.cs`: public contracts.
 - `Response/Response.cs`: `Gravity` response record.
-- `UniverseOptions.cs`: user-facing query-statistics persistence configuration.
+- `UniverseOptions.cs`: user-facing query-statistics persistence, document-cache, and repository provisioning configuration.
 - `global-usings.cs`: shared namespace imports.
 
 ### `code/Universe.Tests`
@@ -361,6 +366,7 @@ Primary consumer entry points:
 - Use `Cluster` / `Catalyst` directly for declarative query construction.
 - Configure serializer behavior with `new UniverseSerializer(...)` on `CosmosClientOptions.Serializer`.
 - Configure tuning persistence with `UniverseOptions.WithFilePersistence(...)` or `UniverseOptions.WithSqlitePersistence(...)`.
+- Enable optional process-local document caching with `UniverseOptions.WithDocumentCache(...)`.
 
 Important public contracts:
 
@@ -387,6 +393,7 @@ Important public contracts:
 6. Query execution uses a strategy selected by `QueryStrategySelector`.
 7. Execution returns `Gravity` plus the requested model/list/projection result.
 8. Query execution statistics are recorded by `QueryTuner` and optionally persisted through `UniverseOptions`.
+9. If document caching is explicitly enabled, point reads and single-document query reads check the process-local cache before executing Cosmos requests.
 
 ## Detailed Operation Flows
 
@@ -464,6 +471,8 @@ Both set `EnableContentResponseOnWrite = false` and convert not found into `{T} 
 
 `Get(id, string partitionKey)` and `Get(id, params string[] partitionKey)` call `ReadItemAsync` and return request charge plus resource. Not found is converted into `{T} does not exist.`
 
+When `UniverseOptions.WithDocumentCache(...)` is configured, direct id reads are cached by hashed database/container/type/id/partition-key scope. Cache hits return `Gravity.RU = 0`. Without `DocumentCache`, the code path only performs a null check and behaves as before.
+
 ### Query Get/List/Paged
 
 `Galaxy<T>.Get(...)`:
@@ -472,6 +481,7 @@ Both set `EnableContentResponseOnWrite = false` and convert not found into `{T} 
 - Executes through `QBuilder.GetOneFromQuery`.
 - Internally forces `MaxItemCount = 1` in the `QueryContext`.
 - Returns first result or `default`.
+- When document caching is enabled, generated SQL and ordered parameter values are normalized into a hashed cache key before execution. Random catalyst ids in parameter names are normalized so equivalent query shapes can hit the same cache entry.
 
 `Galaxy<T>.List(...)`:
 
@@ -798,6 +808,34 @@ Storage behavior:
 - `PlatformDetection.IsAzureEnvironment()` checks `WEBSITE_INSTANCE_ID` and Functions environment variables.
 - `ValidateStoragePath` normalizes with `Path.GetFullPath`, rejects null bytes, and requires a rooted result.
 
+## Optional Document Cache
+
+Document caching is an opt-in add-on configured through `UniverseOptions.WithDocumentCache(...)`. A default `UniverseOptions` instance leaves `DocumentCache` null, and repository read paths do not allocate cache entries, serialize query parameters, clone documents, or build cache keys unless the option is set.
+
+Cached operations:
+
+- `IGalaxyBasic<T>.Get(id, partitionKey...)`
+- `IGalaxy<T>.Get(...)`
+- `IGalaxy<T>.Get<TS>(...)`
+
+Uncached operations:
+
+- `List`
+- `Paged`
+- `GenerateQuery`
+- Query recommendations
+- Stored procedure operations
+
+Invalidation behavior:
+
+- Successful create/modify/remove operations clear same-repository single-document query cache entries.
+- Successful create/modify operations update known point-read entries.
+- Successful remove operations delete known point-read entries.
+- Bulk create and bulk modify update known submitted point entries and clear same-repository query entries after all batches succeed.
+- External writers are not observed; they rely on cache time-to-live expiration.
+
+Cache keys are SHA-256 hashes built from operation kind, database, container, source entity type, result type, and operation inputs. Raw ids, partition-key values, query text, and parameter values are not retained as readable dictionary keys. Cached values are cloned by default with `System.Text.Json` settings aligned with `UniverseSerializer`; clone failures skip or evict the affected cache entry.
+
 ## Data Model And Serialization
 
 `ICosmicEntity` requires:
@@ -866,6 +904,7 @@ Current protections:
 - Identifier segments are rendered as bracketed Cosmos property access.
 - FTScore values are parameterized even in rank ordering.
 - RRF weights are validated as numeric content.
+- Optional document-cache dictionary keys are hashed instead of storing raw ids, partition keys, query text, or parameter values as readable key strings.
 - Query statistics store query hashes and performance metadata, not raw parameter values.
 - `recordQueries` defaults to `false`.
 
@@ -931,6 +970,8 @@ Example sequencing:
 - `Storage/InMemoryStatisticsStorageTests.cs`: in-memory storage behavior.
 - `Storage/PlatformDetectionTests.cs`: path/platform detection behavior.
 - `Storage/SqliteStatisticsStorageTests.cs`: SQLite persistence behavior.
+- `Caching/DocumentCacheTests.cs`: cache key hashing, TTL, eviction, cloning, and query-key normalization behavior.
+- `Caching/DocumentCacheRepositoryTests.cs`: opt-in repository cache behavior using fake Cosmos SDK abstractions.
 - `Tuner/QueryTunerTests.cs`: recommendation and persistence behavior.
 - `Tuner/QueryTunerPerformanceTests.cs`: tuner performance checks.
 - `Helpers/TestStatisticsFactory.cs`: shared test statistics builders.
@@ -996,6 +1037,7 @@ coderabbit review
 ## Common Gotchas
 
 - `recordQueries` is convenient but can expose sensitive parameter values.
+- Document caching is disabled by default; enabling it creates process-local state and external writers are visible after TTL expiration, not through distributed invalidation.
 - `DarkMatter` examples intentionally use debug-style logging and should not define production logging standards.
 - `Paged()` stops after the first non-empty page except for `GROUP BY`, where continuation token behavior is different.
 - Query hints are not accepted with fluent paged queries.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,27 @@ _ = services.AddScoped<IGalaxy<MyModel>, MyRepository>(service => new MyReposito
 ));
 ```
 
+Document caching is available as an opt-in add-on and is disabled by default. It caches direct id/partition-key reads and single-document query reads only; list and paged queries still execute normally.
+
+```csharp
+UniverseOptions options = new UniverseOptions()
+    .WithAutoProvisioning(false)
+    .WithDocumentCache(
+        timeToLive: TimeSpan.FromMinutes(2),
+        maxEntries: 500,
+        cloneDocuments: true);
+
+_ = services.AddScoped<IGalaxy<MyModel>, MyRepository>(service => new MyRepository(
+    client: service.GetRequiredService<CosmosClient>(),
+    database: "database-name",
+    container: "container-name",
+    partitionKey: typeof(MyModel).BuildPartitionKey(),
+    options: options
+));
+```
+
+The cache is process-local memory. Universe invalidates local cached single-document query results on successful create, modify, and remove operations through the same repository scope. Changes made by other processes or direct Cosmos clients are visible after the configured cache time-to-live expires.
+
 5. Inject your `IGalaxy<MyModel>` dependency into your classes and enjoy a simpler way to query CosmosDb
 
 ## Understanding the Gravity Object

--- a/code/Universe.Tests/Caching/DocumentCacheRepositoryTests.cs
+++ b/code/Universe.Tests/Caching/DocumentCacheRepositoryTests.cs
@@ -1,0 +1,312 @@
+using System.Collections;
+using System.Net;
+using System.Reflection;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Scripts;
+using Universe.Attributes;
+using Universe.Extensions;
+using Universe.Interfaces;
+using Universe.Response;
+using Xunit;
+
+namespace Universe.Tests.Caching;
+
+public sealed class DocumentCacheRepositoryTests
+{
+    [Fact]
+    public async Task PointGet_CacheDisabled_ReadsContainerEveryTime()
+    {
+        FakeContainer container = new()
+        {
+            ReadItemResult = new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "from-cosmos" }
+        };
+        TestGalaxy repo = new(container, new UniverseOptions().WithAutoProvisioning(false));
+
+        (_, CacheEntity first) = await repo.PointGet("id-1", "tenant-1");
+        (_, CacheEntity second) = await repo.PointGet("id-1", "tenant-1");
+
+        Assert.Equal("from-cosmos", first.Name);
+        Assert.Equal("from-cosmos", second.Name);
+        Assert.Equal(2, container.ReadItemCalls);
+    }
+
+    [Fact]
+    public async Task PointGet_CacheEnabled_ReturnsSecondReadFromCache()
+    {
+        FakeContainer container = new()
+        {
+            ReadItemResult = new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "from-cosmos" }
+        };
+        TestGalaxy repo = new(container, new UniverseOptions().WithAutoProvisioning(false).WithDocumentCache());
+
+        (Gravity firstGravity, CacheEntity first) = await repo.PointGet("id-1", "tenant-1");
+        first.Name = "caller-mutation";
+        (Gravity secondGravity, CacheEntity second) = await repo.PointGet("id-1", "tenant-1");
+
+        Assert.Equal(9.5, firstGravity.RU);
+        Assert.Equal(0, secondGravity.RU);
+        Assert.Equal("from-cosmos", second.Name);
+        Assert.Equal(1, container.ReadItemCalls);
+    }
+
+    [Fact]
+    public async Task QueryGet_CacheEnabled_UsesStableKeyAcrossGeneratedCatalystIds()
+    {
+        FakeContainer container = new()
+        {
+            QueryItems = [new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "from-cosmos" }]
+        };
+        TestGalaxy repo = new(container, new UniverseOptions().WithAutoProvisioning(false).WithDocumentCache());
+
+        (Gravity firstGravity, CacheEntity first) = await repo.QueryGet("same-name");
+        (Gravity secondGravity, CacheEntity second) = await repo.QueryGet("same-name");
+
+        Assert.Equal(7.25, firstGravity.RU);
+        Assert.Equal(0, secondGravity.RU);
+        Assert.Equal("from-cosmos", first.Name);
+        Assert.Equal("from-cosmos", second.Name);
+        Assert.Equal(1, container.QueryCalls);
+    }
+
+    [Fact]
+    public async Task QueryGet_CacheHit_PreservesRecordedQueryDetails()
+    {
+        FakeContainer container = new()
+        {
+            QueryItems = [new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "from-cosmos" }]
+        };
+        TestGalaxy repo = new(container, new UniverseOptions().WithAutoProvisioning(false).WithDocumentCache(), recordQueries: true);
+
+        await repo.QueryGet("same-name");
+        (Gravity secondGravity, _) = await repo.QueryGet("same-name");
+
+        Assert.Equal(0, secondGravity.RU);
+        Assert.StartsWith("SELECT", secondGravity.Query.Text);
+        Assert.NotEmpty(secondGravity.Query.Parameters);
+        Assert.Equal(1, container.QueryCalls);
+    }
+
+    [Fact]
+    public async Task Modify_UpdatesPointReadCache()
+    {
+        FakeContainer container = new()
+        {
+            ReadItemResult = new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "before" },
+            ReplaceItemResult = new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "after" }
+        };
+        TestGalaxy repo = new(container, new UniverseOptions().WithAutoProvisioning(false).WithDocumentCache());
+
+        await repo.PointGet("id-1", "tenant-1");
+        await repo.ModifyEntity(new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "after" });
+        (Gravity gravity, CacheEntity cached) = await repo.PointGet("id-1", "tenant-1");
+
+        Assert.Equal(0, gravity.RU);
+        Assert.Equal("after", cached.Name);
+        Assert.Equal(1, container.ReadItemCalls);
+    }
+
+    [Fact]
+    public async Task Modify_ClearsSingleQueryCacheForRepositoryScope()
+    {
+        FakeContainer container = new()
+        {
+            QueryItems = [new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "before" }],
+            ReplaceItemResult = new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "after" }
+        };
+        TestGalaxy repo = new(container, new UniverseOptions().WithAutoProvisioning(false).WithDocumentCache());
+
+        await repo.QueryGet("same-name");
+        await repo.QueryGet("same-name");
+        await repo.ModifyEntity(new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "after" });
+        container.QueryItems = [new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "after" }];
+        (_, CacheEntity afterInvalidation) = await repo.QueryGet("same-name");
+
+        Assert.Equal("after", afterInvalidation.Name);
+        Assert.Equal(2, container.QueryCalls);
+    }
+
+    [Fact]
+    public async Task Remove_InvalidatesPointReadCache()
+    {
+        FakeContainer container = new()
+        {
+            ReadItemResult = new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "before" }
+        };
+        TestGalaxy repo = new(container, new UniverseOptions().WithAutoProvisioning(false).WithDocumentCache());
+
+        await repo.PointGet("id-1", "tenant-1");
+        await repo.RemoveEntity("id-1", "tenant-1");
+        container.ReadItemResult = new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "after" };
+        (_, CacheEntity afterInvalidation) = await repo.PointGet("id-1", "tenant-1");
+
+        Assert.Equal("after", afterInvalidation.Name);
+        Assert.Equal(2, container.ReadItemCalls);
+    }
+
+    private sealed class TestGalaxy : Galaxy<CacheEntity>
+    {
+        public TestGalaxy(FakeContainer container, UniverseOptions options, bool recordQueries = false)
+            : base(CreateClient(), "database", "container", typeof(CacheEntity).BuildPartitionKey(), options, recordQueries)
+        {
+            typeof(GalaxyCore)
+                .GetField("_container", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.SetValue(this, container);
+        }
+
+        public Task<(Gravity, CacheEntity)> PointGet(string id, string tenantId)
+            => ((IGalaxyBasic<CacheEntity>)this).Get(id, tenantId);
+
+        public Task<(Gravity, CacheEntity)> QueryGet(string name)
+            => ((IGalaxy<CacheEntity>)this).Get([new([new("Name", name)])]);
+
+        public Task<(Gravity, CacheEntity)> ModifyEntity(CacheEntity entity)
+            => ((IGalaxyBasic<CacheEntity>)this).Modify(entity);
+
+        public Task<Gravity> RemoveEntity(string id, string tenantId)
+            => ((IGalaxyBasic<CacheEntity>)this).Remove(id, tenantId);
+
+        private static CosmosClient CreateClient()
+            => new(
+                "https://localhost:8081",
+                Convert.ToBase64String(new byte[64]),
+                new CosmosClientOptions { AllowBulkExecution = true });
+    }
+
+    private sealed record CacheEntity : CosmicEntity
+    {
+        [PartitionKey]
+        public string TenantId { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    private sealed class FakeContainer : Container
+    {
+        public CacheEntity ReadItemResult { get; set; }
+        public CacheEntity ReplaceItemResult { get; set; }
+        public IReadOnlyList<CacheEntity> QueryItems { get; set; } = [];
+        public int ReadItemCalls { get; private set; }
+        public int QueryCalls { get; private set; }
+
+        public override string Id => "container";
+        public override Database Database => throw new NotSupportedException();
+        public override Conflicts Conflicts => throw new NotSupportedException();
+        public override Scripts Scripts => throw new NotSupportedException();
+
+        public override Task<ItemResponse<T>> ReadItemAsync<T>(string id, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+        {
+            ReadItemCalls++;
+            return Task.FromResult<ItemResponse<T>>(new FakeItemResponse<T>((T)(object)ReadItemResult, 9.5));
+        }
+
+        public override Task<ItemResponse<T>> ReplaceItemAsync<T>(T item, string id, PartitionKey? partitionKey = null, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<ItemResponse<T>>(new FakeItemResponse<T>((T)(object)ReplaceItemResult, 6.5));
+
+        public override Task<ItemResponse<T>> DeleteItemAsync<T>(string id, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<ItemResponse<T>>(new FakeItemResponse<T>(default, 4.5));
+
+        public override FeedIterator<T> GetItemQueryIterator<T>(QueryDefinition queryDefinition, string continuationToken = null, QueryRequestOptions requestOptions = null)
+        {
+            QueryCalls++;
+            return new FakeFeedIterator<T>(QueryItems.Cast<T>().ToArray(), 7.25);
+        }
+
+        public override Task<ItemResponse<T>> CreateItemAsync<T>(T item, PartitionKey? partitionKey = null, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default)
+            => Task.FromResult<ItemResponse<T>>(new FakeItemResponse<T>(item, 5.5));
+
+        public override TransactionalBatch CreateTransactionalBatch(PartitionKey partitionKey)
+            => new FakeTransactionalBatch();
+
+        public override Task<ContainerResponse> ReadContainerAsync(ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ResponseMessage> ReadContainerStreamAsync(ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ContainerResponse> ReplaceContainerAsync(ContainerProperties containerProperties, ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ResponseMessage> ReplaceContainerStreamAsync(ContainerProperties containerProperties, ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ContainerResponse> DeleteContainerAsync(ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ResponseMessage> DeleteContainerStreamAsync(ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<int?> ReadThroughputAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ThroughputResponse> ReadThroughputAsync(RequestOptions requestOptions, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ThroughputResponse> ReplaceThroughputAsync(int throughput, RequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ThroughputResponse> ReplaceThroughputAsync(ThroughputProperties throughputProperties, RequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ResponseMessage> CreateItemStreamAsync(Stream streamPayload, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ResponseMessage> ReadItemStreamAsync(string id, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ResponseMessage> UpsertItemStreamAsync(Stream streamPayload, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ItemResponse<T>> UpsertItemAsync<T>(T item, PartitionKey? partitionKey = null, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ResponseMessage> ReplaceItemStreamAsync(Stream streamPayload, string id, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<FeedResponse<T>> ReadManyItemsAsync<T>(IReadOnlyList<(string id, PartitionKey partitionKey)> items, ReadManyRequestOptions readManyRequestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ResponseMessage> ReadManyItemsStreamAsync(IReadOnlyList<(string id, PartitionKey partitionKey)> items, ReadManyRequestOptions readManyRequestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ItemResponse<T>> PatchItemAsync<T>(string id, PartitionKey partitionKey, IReadOnlyList<PatchOperation> patchOperations, PatchItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ResponseMessage> PatchItemStreamAsync(string id, PartitionKey partitionKey, IReadOnlyList<PatchOperation> patchOperations, PatchItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override Task<ResponseMessage> DeleteItemStreamAsync(string id, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override FeedIterator GetItemQueryStreamIterator(QueryDefinition queryDefinition, string continuationToken = null, QueryRequestOptions requestOptions = null) => throw new NotSupportedException();
+        public override FeedIterator GetItemQueryStreamIterator(string queryText = null, string continuationToken = null, QueryRequestOptions requestOptions = null) => throw new NotSupportedException();
+        public override FeedIterator<T> GetItemQueryIterator<T>(string queryText = null, string continuationToken = null, QueryRequestOptions requestOptions = null) => throw new NotSupportedException();
+        public override FeedIterator GetItemQueryStreamIterator(FeedRange feedRange, QueryDefinition queryDefinition, string continuationToken = null, QueryRequestOptions requestOptions = null) => throw new NotSupportedException();
+        public override FeedIterator<T> GetItemQueryIterator<T>(FeedRange feedRange, QueryDefinition queryDefinition, string continuationToken = null, QueryRequestOptions requestOptions = null) => throw new NotSupportedException();
+        public override IOrderedQueryable<T> GetItemLinqQueryable<T>(bool allowSynchronousQueryExecution = false, string continuationToken = null, QueryRequestOptions requestOptions = null, CosmosLinqSerializerOptions linqSerializerOptions = null) => throw new NotSupportedException();
+        public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder<T>(string processorName, ChangesHandler<T> onChangesDelegate) => throw new NotSupportedException();
+        public override ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(string processorName, ChangesEstimationHandler estimationDelegate, TimeSpan? estimationPeriod = null) => throw new NotSupportedException();
+        public override ChangeFeedEstimator GetChangeFeedEstimator(string processorName, Container leaseContainer) => throw new NotSupportedException();
+        public override Task<IReadOnlyList<FeedRange>> GetFeedRangesAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public override FeedIterator GetChangeFeedStreamIterator(ChangeFeedStartFrom changeFeedStartFrom, ChangeFeedMode changeFeedMode, ChangeFeedRequestOptions changeFeedRequestOptions = null) => throw new NotSupportedException();
+        public override FeedIterator<T> GetChangeFeedIterator<T>(ChangeFeedStartFrom changeFeedStartFrom, ChangeFeedMode changeFeedMode, ChangeFeedRequestOptions changeFeedRequestOptions = null) => throw new NotSupportedException();
+        public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder<T>(string processorName, ChangeFeedHandler<T> onChangesDelegate) => throw new NotSupportedException();
+        public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilderWithManualCheckpoint<T>(string processorName, ChangeFeedHandlerWithManualCheckpoint<T> onChangesDelegate) => throw new NotSupportedException();
+        public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder(string processorName, ChangeFeedStreamHandler onChangesDelegate) => throw new NotSupportedException();
+        public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilderWithManualCheckpoint(string processorName, ChangeFeedStreamHandlerWithManualCheckpoint onChangesDelegate) => throw new NotSupportedException();
+    }
+
+    private sealed class FakeItemResponse<T>(T resource, double requestCharge) : ItemResponse<T>
+    {
+        public override T Resource => resource;
+        public override double RequestCharge => requestCharge;
+        public override HttpStatusCode StatusCode => HttpStatusCode.OK;
+    }
+
+    private sealed class FakeFeedIterator<T>(IReadOnlyList<T> items, double requestCharge) : FeedIterator<T>
+    {
+        private bool _hasMoreResults = true;
+
+        public override bool HasMoreResults => _hasMoreResults;
+
+        public override Task<FeedResponse<T>> ReadNextAsync(CancellationToken cancellationToken = default)
+        {
+            _hasMoreResults = false;
+            return Task.FromResult<FeedResponse<T>>(new FakeFeedResponse<T>(items, requestCharge));
+        }
+    }
+
+    private sealed class FakeFeedResponse<T>(IReadOnlyList<T> items, double requestCharge) : FeedResponse<T>
+    {
+        public override string ContinuationToken => null;
+        public override int Count => items.Count;
+        public override string IndexMetrics => string.Empty;
+        public override Headers Headers => null;
+        public override IEnumerable<T> Resource => items;
+        public override HttpStatusCode StatusCode => HttpStatusCode.OK;
+        public override CosmosDiagnostics Diagnostics => null;
+        public override double RequestCharge => requestCharge;
+        public override IEnumerator<T> GetEnumerator() => items.GetEnumerator();
+    }
+
+    private sealed class FakeTransactionalBatch : TransactionalBatch
+    {
+        public override TransactionalBatch CreateItem<T>(T item, TransactionalBatchItemRequestOptions requestOptions = null) => this;
+        public override TransactionalBatch CreateItemStream(Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null) => this;
+        public override TransactionalBatch ReadItem(string id, TransactionalBatchItemRequestOptions requestOptions = null) => this;
+        public override TransactionalBatch UpsertItem<T>(T item, TransactionalBatchItemRequestOptions requestOptions = null) => this;
+        public override TransactionalBatch UpsertItemStream(Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null) => this;
+        public override TransactionalBatch ReplaceItem<T>(string id, T item, TransactionalBatchItemRequestOptions requestOptions = null) => this;
+        public override TransactionalBatch ReplaceItemStream(string id, Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null) => this;
+        public override TransactionalBatch DeleteItem(string id, TransactionalBatchItemRequestOptions requestOptions = null) => this;
+        public override TransactionalBatch PatchItem(string id, IReadOnlyList<PatchOperation> patchOperations, TransactionalBatchPatchItemRequestOptions requestOptions = null) => this;
+        public override Task<TransactionalBatchResponse> ExecuteAsync(CancellationToken cancellationToken = default) => Task.FromResult<TransactionalBatchResponse>(new FakeTransactionalBatchResponse());
+        public override Task<TransactionalBatchResponse> ExecuteAsync(TransactionalBatchRequestOptions requestOptions, CancellationToken cancellationToken = default) => Task.FromResult<TransactionalBatchResponse>(new FakeTransactionalBatchResponse());
+    }
+
+    private sealed class FakeTransactionalBatchResponse : TransactionalBatchResponse
+    {
+        public override bool IsSuccessStatusCode => true;
+        public override HttpStatusCode StatusCode => HttpStatusCode.OK;
+        public override double RequestCharge => 3.5;
+    }
+}

--- a/code/Universe.Tests/Caching/DocumentCacheTests.cs
+++ b/code/Universe.Tests/Caching/DocumentCacheTests.cs
@@ -1,0 +1,138 @@
+using Universe.Builder.Caching;
+using Universe.Attributes;
+using Universe.Interfaces;
+using Xunit;
+
+namespace Universe.Tests.Caching;
+
+public sealed class DocumentCacheTests
+{
+    [Fact]
+    public void PointKey_DoesNotContainReadableInputs()
+    {
+        DocumentCache cache = new(new(TimeSpan.FromMinutes(5), 1000, cloneDocuments: true));
+
+        DocumentCacheKey key = cache.CreatePointKey(
+            database: "db-secret",
+            container: "container-secret",
+            sourceType: typeof(CacheEntity),
+            resultType: typeof(CacheEntity),
+            id: "document-secret",
+            partitionKeys: ["tenant-secret"]);
+
+        Assert.DoesNotContain("db-secret", key.Value);
+        Assert.DoesNotContain("container-secret", key.Value);
+        Assert.DoesNotContain("document-secret", key.Value);
+        Assert.DoesNotContain("tenant-secret", key.Value);
+        Assert.Equal(64, key.Value.Length);
+    }
+
+    [Fact]
+    public void TryGet_ReturnsFalseAfterExpiration()
+    {
+        DocumentCache cache = new(new(TimeSpan.FromMilliseconds(1), 1000, cloneDocuments: true));
+        DocumentCacheKey key = cache.CreatePointKey("db", "container", typeof(CacheEntity), typeof(CacheEntity), "id-1", ["tenant-1"]);
+
+        cache.Set(key, DocumentCacheOperation.PointRead, scopeHash: "scope", new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "cached" });
+        Thread.Sleep(20);
+
+        bool found = cache.TryGet<CacheEntity>(key, out CacheEntity value);
+
+        Assert.False(found);
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void TryGet_ClonesCachedValueByDefault()
+    {
+        DocumentCache cache = new(new(TimeSpan.FromMinutes(5), 1000, cloneDocuments: true));
+        DocumentCacheKey key = cache.CreatePointKey("db", "container", typeof(CacheEntity), typeof(CacheEntity), "id-1", ["tenant-1"]);
+
+        cache.Set(key, DocumentCacheOperation.PointRead, scopeHash: "scope", new CacheEntity { id = "id-1", TenantId = "tenant-1", Name = "cached" });
+
+        Assert.True(cache.TryGet(key, out CacheEntity first));
+        first.Name = "mutated";
+        Assert.True(cache.TryGet(key, out CacheEntity second));
+
+        Assert.Equal("cached", second.Name);
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void TryGet_ReturnsSameInstanceWhenCloningDisabled()
+    {
+        DocumentCache cache = new(new(TimeSpan.FromMinutes(5), 1000, cloneDocuments: false));
+        DocumentCacheKey key = cache.CreatePointKey("db", "container", typeof(CacheEntity), typeof(CacheEntity), "id-1", ["tenant-1"]);
+        CacheEntity entity = new() { id = "id-1", TenantId = "tenant-1", Name = "cached" };
+
+        cache.Set(key, DocumentCacheOperation.PointRead, scopeHash: "scope", entity);
+
+        Assert.True(cache.TryGet(key, out CacheEntity first));
+        Assert.True(cache.TryGet(key, out CacheEntity second));
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void Set_EvictsOldestEntryWhenMaxEntriesExceeded()
+    {
+        DocumentCache cache = new(new(TimeSpan.FromMinutes(5), 1, cloneDocuments: true));
+        DocumentCacheKey firstKey = cache.CreatePointKey("db", "container", typeof(CacheEntity), typeof(CacheEntity), "id-1", ["tenant-1"]);
+        DocumentCacheKey secondKey = cache.CreatePointKey("db", "container", typeof(CacheEntity), typeof(CacheEntity), "id-2", ["tenant-1"]);
+
+        cache.Set(firstKey, DocumentCacheOperation.PointRead, scopeHash: "scope", new CacheEntity { id = "id-1", TenantId = "tenant-1" });
+        cache.Set(secondKey, DocumentCacheOperation.PointRead, scopeHash: "scope", new CacheEntity { id = "id-2", TenantId = "tenant-1" });
+
+        Assert.False(cache.TryGet(firstKey, out CacheEntity first));
+        Assert.True(cache.TryGet(secondKey, out CacheEntity second));
+        Assert.Equal("id-2", second.id);
+    }
+
+    [Fact]
+    public void ClearQueries_RemovesOnlyQueryEntriesForScope()
+    {
+        DocumentCache cache = new(new(TimeSpan.FromMinutes(5), 1000, cloneDocuments: true));
+        DocumentCacheKey queryKey = cache.CreateQueryKey("db", "container", typeof(CacheEntity), typeof(CacheEntity), "SELECT * FROM c", []);
+        DocumentCacheKey pointKey = cache.CreatePointKey("db", "container", typeof(CacheEntity), typeof(CacheEntity), "id-1", ["tenant-1"]);
+
+        string scopeHash = cache.CreateScopeHash("db", "container", typeof(CacheEntity));
+        cache.Set(queryKey, DocumentCacheOperation.SingleQuery, scopeHash, new CacheEntity { id = "id-1", TenantId = "tenant-1" });
+        cache.Set(pointKey, DocumentCacheOperation.PointRead, scopeHash, new CacheEntity { id = "id-1", TenantId = "tenant-1" });
+
+        cache.ClearQueries(scopeHash);
+
+        Assert.False(cache.TryGet(queryKey, out CacheEntity queryValue));
+        Assert.True(cache.TryGet(pointKey, out CacheEntity pointValue));
+    }
+
+    [Fact]
+    public void QueryKey_NormalizesGeneratedParameterNames()
+    {
+        DocumentCache cache = new(new(TimeSpan.FromMinutes(5), 1000, cloneDocuments: true));
+
+        DocumentCacheKey first = cache.CreateQueryKey(
+            "db",
+            "container",
+            typeof(CacheEntity),
+            typeof(CacheEntity),
+            "SELECT * FROM c WHERE c[\"name\"] = @name018f1",
+            [("@name018f1", "value")]);
+        DocumentCacheKey second = cache.CreateQueryKey(
+            "db",
+            "container",
+            typeof(CacheEntity),
+            typeof(CacheEntity),
+            "SELECT * FROM c WHERE c[\"name\"] = @name999f2",
+            [("@name999f2", "value")]);
+
+        Assert.Equal(first, second);
+    }
+
+    private sealed record CacheEntity : CosmicEntity
+    {
+        [PartitionKey]
+        public string TenantId { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/code/Universe.Tests/Storage/UniverseOptionsTests.cs
+++ b/code/Universe.Tests/Storage/UniverseOptionsTests.cs
@@ -41,6 +41,67 @@ public sealed class UniverseOptionsTests : IDisposable
     }
 
     [Fact]
+    public void DefaultOptions_DisableDocumentCache()
+    {
+        UniverseOptions options = new();
+
+        Assert.Null(options.DocumentCache);
+    }
+
+    [Fact]
+    public void WithDocumentCache_EnablesDocumentCacheWithDefaults()
+    {
+        UniverseOptions options = new UniverseOptions().WithDocumentCache();
+
+        Assert.NotNull(options.DocumentCache);
+        Assert.Equal(TimeSpan.FromMinutes(5), options.DocumentCache.TimeToLive);
+        Assert.Equal(1000, options.DocumentCache.MaxEntries);
+        Assert.True(options.DocumentCache.CloneDocuments);
+    }
+
+    [Fact]
+    public void WithDocumentCache_AcceptsCustomOptions()
+    {
+        UniverseOptions options = new UniverseOptions().WithDocumentCache(
+            timeToLive: TimeSpan.FromSeconds(30),
+            maxEntries: 25,
+            cloneDocuments: false);
+
+        Assert.NotNull(options.DocumentCache);
+        Assert.Equal(TimeSpan.FromSeconds(30), options.DocumentCache.TimeToLive);
+        Assert.Equal(25, options.DocumentCache.MaxEntries);
+        Assert.False(options.DocumentCache.CloneDocuments);
+    }
+
+    [Fact]
+    public void WithoutDocumentCache_DisablesDocumentCache()
+    {
+        UniverseOptions options = new UniverseOptions()
+            .WithDocumentCache()
+            .WithoutDocumentCache();
+
+        Assert.Null(options.DocumentCache);
+    }
+
+    [Fact]
+    public void WithDocumentCache_InvalidTimeToLive_ThrowsUniverseException()
+    {
+        UniverseException exception = Assert.Throws<UniverseException>(
+            () => new UniverseOptions().WithDocumentCache(TimeSpan.Zero));
+
+        Assert.Equal("Document cache time-to-live must be greater than zero.", exception.Message);
+    }
+
+    [Fact]
+    public void WithDocumentCache_InvalidMaxEntries_ThrowsUniverseException()
+    {
+        UniverseException exception = Assert.Throws<UniverseException>(
+            () => new UniverseOptions().WithDocumentCache(maxEntries: 0));
+
+        Assert.Equal("Document cache max entries must be greater than zero.", exception.Message);
+    }
+
+    [Fact]
     public void WithAutoProvisioningFalse_DisablesAutoProvisioning()
     {
         UniverseOptions options = new UniverseOptions().WithAutoProvisioning(false);
@@ -67,6 +128,25 @@ public sealed class UniverseOptionsTests : IDisposable
             options = options.WithAutoProvisioning(false);
 
             Assert.False(options.AutoProvisionContainers);
+            Assert.IsType<FileStatisticsStorage>(options.StatisticsStorage);
+        }
+        finally
+        {
+            DisposeStatisticsStorage(options);
+        }
+    }
+
+    [Fact]
+    public void FilePersistence_WithDocumentCache_PreservesStorage()
+    {
+        string path = Track(Path.Combine(AppContext.BaseDirectory, $"options-{Guid.NewGuid()}.json"));
+
+        UniverseOptions options = UniverseOptions.WithFilePersistence(path);
+        try
+        {
+            options = options.WithDocumentCache(TimeSpan.FromSeconds(15), 10);
+
+            Assert.NotNull(options.DocumentCache);
             Assert.IsType<FileStatisticsStorage>(options.StatisticsStorage);
         }
         finally

--- a/code/Universe/Builder/Caching/DocumentCache.cs
+++ b/code/Universe/Builder/Caching/DocumentCache.cs
@@ -1,0 +1,167 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Universe.Builder.Caching;
+
+internal readonly record struct DocumentCacheKey(string Value);
+
+internal enum DocumentCacheOperation
+{
+    PointRead,
+    SingleQuery
+}
+
+internal sealed class DocumentCache(DocumentCacheOptions options)
+{
+    private static readonly Regex ParameterNamePattern = new(@"@\w+", RegexOptions.Compiled);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
+        IgnoreReadOnlyFields = true,
+        IgnoreReadOnlyProperties = true
+    };
+
+    private readonly ConcurrentDictionary<DocumentCacheKey, DocumentCacheEntry> _entries = [];
+    private readonly ConcurrentQueue<DocumentCacheKey> _insertionOrder = [];
+
+    internal string CreateScopeHash(string database, string container, Type sourceType)
+        => HashParts(["scope", database, container, sourceType.AssemblyQualifiedName]);
+
+    internal DocumentCacheKey CreatePointKey(
+        string database,
+        string container,
+        Type sourceType,
+        Type resultType,
+        string id,
+        IReadOnlyList<string> partitionKeys)
+        => new(HashParts([
+            "point",
+            database,
+            container,
+            sourceType.AssemblyQualifiedName,
+            resultType.AssemblyQualifiedName,
+            id,
+            .. partitionKeys
+        ]));
+
+    internal DocumentCacheKey CreateQueryKey(
+        string database,
+        string container,
+        Type sourceType,
+        Type resultType,
+        string queryText,
+        IReadOnlyList<(string Name, object Value)> parameters)
+    {
+        string normalizedQuery = ParameterNamePattern.Replace(queryText, "@p");
+        List<string> parts =
+        [
+            "query",
+            database,
+            container,
+            sourceType.AssemblyQualifiedName,
+            resultType.AssemblyQualifiedName,
+            normalizedQuery
+        ];
+
+        foreach ((_, object value) in parameters)
+            parts.Add(SerializeForKey(value));
+
+        return new(HashParts(parts));
+    }
+
+    internal bool TryGet<T>(DocumentCacheKey key, out T value)
+    {
+        value = default;
+
+        if (!_entries.TryGetValue(key, out DocumentCacheEntry entry))
+            return false;
+
+        if (DateTimeOffset.UtcNow - entry.CreatedOn >= options.TimeToLive)
+        {
+            _entries.TryRemove(key, out _);
+            return false;
+        }
+
+        try
+        {
+            value = CloneIfNeeded<T>(entry.Value);
+            return true;
+        }
+        catch (SystemException)
+        {
+            _entries.TryRemove(key, out _);
+            value = default;
+            return false;
+        }
+    }
+
+    internal void Set(DocumentCacheKey key, DocumentCacheOperation operation, string scopeHash, object value)
+    {
+        object valueToStore;
+        try
+        {
+            valueToStore = options.CloneDocuments ? CloneIfNeeded<object>(value) : value;
+        }
+        catch (SystemException)
+        {
+            return;
+        }
+
+        _entries[key] = new(valueToStore, DateTimeOffset.UtcNow, operation, scopeHash);
+        _insertionOrder.Enqueue(key);
+        EnforceMaxEntries();
+    }
+
+    internal void Remove(DocumentCacheKey key) => _entries.TryRemove(key, out _);
+
+    internal void ClearQueries(string scopeHash)
+    {
+        foreach (KeyValuePair<DocumentCacheKey, DocumentCacheEntry> entry in _entries)
+        {
+            if (entry.Value.ScopeHash == scopeHash && entry.Value.Operation is DocumentCacheOperation.SingleQuery)
+                _entries.TryRemove(entry.Key, out _);
+        }
+    }
+
+    private void EnforceMaxEntries()
+    {
+        while (_entries.Count > options.MaxEntries && _insertionOrder.TryDequeue(out DocumentCacheKey key))
+            _entries.TryRemove(key, out _);
+    }
+
+    private T CloneIfNeeded<T>(object value)
+    {
+        if (!options.CloneDocuments || value is null)
+            return (T)value;
+
+        Type valueType = value.GetType();
+        string json = JsonSerializer.Serialize(value, valueType, JsonOptions);
+        return (T)JsonSerializer.Deserialize(json, valueType, JsonOptions);
+    }
+
+    private static string SerializeForKey(object value)
+    {
+        if (value is null)
+            return "null";
+
+        return JsonSerializer.Serialize(value, value.GetType(), JsonOptions);
+    }
+
+    private static string HashParts(IEnumerable<string> parts)
+    {
+        string payload = JsonSerializer.Serialize(parts, JsonOptions);
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private sealed record DocumentCacheEntry(
+        object Value,
+        DateTimeOffset CreatedOn,
+        DocumentCacheOperation Operation,
+        string ScopeHash);
+}

--- a/code/Universe/DocumentCacheOptions.cs
+++ b/code/Universe/DocumentCacheOptions.cs
@@ -1,0 +1,40 @@
+namespace Universe;
+
+/// <summary>
+/// Optional in-memory document cache configuration.
+/// </summary>
+public sealed class DocumentCacheOptions
+{
+    /// <summary>Default cache entry time-to-live.</summary>
+    public static readonly TimeSpan DefaultTimeToLive = TimeSpan.FromMinutes(5);
+
+    /// <summary>Default maximum number of cached entries.</summary>
+    public const int DefaultMaxEntries = 1000;
+
+    /// <summary>How long cached documents remain valid.</summary>
+    public TimeSpan TimeToLive { get; }
+
+    /// <summary>Maximum number of entries retained by the cache.</summary>
+    public int MaxEntries { get; }
+
+    /// <summary>Whether cache reads and writes clone document instances.</summary>
+    public bool CloneDocuments { get; }
+
+    internal Builder.Caching.DocumentCache Cache { get; }
+
+    /// <summary>Create document cache options.</summary>
+    public DocumentCacheOptions(TimeSpan? timeToLive = null, int maxEntries = DefaultMaxEntries, bool cloneDocuments = true)
+    {
+        TimeSpan resolvedTimeToLive = timeToLive ?? DefaultTimeToLive;
+        if (resolvedTimeToLive <= TimeSpan.Zero)
+            throw new UniverseException("Document cache time-to-live must be greater than zero.");
+
+        if (maxEntries <= 0)
+            throw new UniverseException("Document cache max entries must be greater than zero.");
+
+        TimeToLive = resolvedTimeToLive;
+        MaxEntries = maxEntries;
+        CloneDocuments = cloneDocuments;
+        Cache = new(this);
+    }
+}

--- a/code/Universe/Galaxy.cs
+++ b/code/Universe/Galaxy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using Universe.Builder.Caching;
 using Universe.Response;
 using Universe.Builder.Strategies;
 
@@ -51,7 +52,12 @@ public abstract class Galaxy<T> : GalaxyBasic<T>, IGalaxy<T> where T : class, IC
         try
         {
             QueryDefinition query = QBuilder.CreateQuery(clusters, columnOptions: columns is null || !columns.Any() ? null : new(columns));
-            return await QBuilder.GetOneFromQuery<TArgType>(_container, query);
+            if (TryGetQueryCache(query, out TArgType cached, out IReadOnlyList<(string, object)> cacheParameters))
+                return (new(0, null, _recordQuery ? (query.QueryText, cacheParameters) : default), cached);
+
+            (Gravity gravity, TArgType result) = await QBuilder.GetOneFromQuery<TArgType>(_container, query);
+            SetQueryCache(query, result);
+            return (gravity, result);
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
@@ -116,6 +122,52 @@ public abstract class Galaxy<T> : GalaxyBasic<T>, IGalaxy<T> where T : class, IC
     }
 
     QueryTuningRecommendations IGalaxy<T>.GetQueryRecommendations(string queryPattern, QueryType queryType) => QBuilder.GetQueryRecommendations(queryType);
+
+    private bool TryGetQueryCache<TArgType>(QueryDefinition query, out TArgType value, out IReadOnlyList<(string, object)> parameters)
+    {
+        value = default;
+        parameters = default;
+        DocumentCache cache = DocumentCache;
+        if (cache is null)
+            return false;
+
+        if (!TryCreateQueryCacheKey<TArgType>(cache, query, out DocumentCacheKey key, out parameters))
+            return false;
+
+        return cache.TryGet(key, out value);
+    }
+
+    private void SetQueryCache<TArgType>(QueryDefinition query, TArgType value)
+    {
+        DocumentCache cache = DocumentCache;
+        if (cache is null)
+            return;
+
+        if (!TryCreateQueryCacheKey<TArgType>(cache, query, out DocumentCacheKey key, out _))
+            return;
+
+        cache.Set(key, DocumentCacheOperation.SingleQuery, DocumentCacheScopeHash(typeof(T)), value);
+    }
+
+    private bool TryCreateQueryCacheKey<TArgType>(
+        DocumentCache cache,
+        QueryDefinition query,
+        out DocumentCacheKey key,
+        out IReadOnlyList<(string, object)> parameters)
+    {
+        key = default;
+        parameters = default;
+        try
+        {
+            parameters = query.GetQueryParameters();
+            key = cache.CreateQueryKey(_databaseName, _containerName, typeof(T), typeof(TArgType), query.QueryText, parameters);
+            return true;
+        }
+        catch (SystemException)
+        {
+            return false;
+        }
+    }
 
     private async Task<(Gravity g, IList<TArgType> T)> InternalListWithHints<TArgType>(IReadOnlyList<Cluster> clusters, ColumnOptions? columnOptions, IReadOnlyList<Sorting.Option> sorting, IReadOnlyList<string> group, QueryHints? hints)
     {

--- a/code/Universe/GalaxyBasic.cs
+++ b/code/Universe/GalaxyBasic.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text.Json;
 using Universe.Builder;
+using Universe.Builder.Caching;
 using Universe.Builder.Strategies;
 using Universe.Response;
 
@@ -57,6 +58,8 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
                 {
                     EnableContentResponseOnWrite = false
                 });
+            SetPointCache(model);
+            ClearQueryCache();
             return (new(response.RequestCharge, null), model.id);
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
@@ -117,6 +120,10 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
             await Task.WhenAll(tasks);
             double totalRu = tasks.Sum(t => t.Result);
 
+            foreach (T model in models)
+                SetPointCache(model);
+
+            ClearQueryCache();
             return new(totalRu, string.Empty);
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
@@ -136,6 +143,8 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
             model.ModifiedOn = DateTime.UtcNow;
 
             ItemResponse<T> response = await _container.ReplaceItemAsync(model, model.id, model.BuildPartitionKey());
+            SetPointCache(response.Resource ?? model);
+            ClearQueryCache();
             return (new(response.RequestCharge, null), response.Resource);
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
@@ -194,6 +203,10 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
             await Task.WhenAll(tasks);
             double totalRu = tasks.Sum(t => t.Result);
 
+            foreach (T model in models)
+                SetPointCache(model);
+
+            ClearQueryCache();
             return new(totalRu, string.Empty);
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
@@ -231,6 +244,8 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
             {
                 EnableContentResponseOnWrite = false
             });
+            RemovePointCache(id, partitionKey);
+            ClearQueryCache();
             return new(response.RequestCharge, null);
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
@@ -251,6 +266,8 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
             {
                 EnableContentResponseOnWrite = false
             });
+            RemovePointCache(id, [partitionKey]);
+            ClearQueryCache();
             return new(response.RequestCharge, null);
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
@@ -267,7 +284,11 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
     {
         try
         {
+            if (TryGetPointCache(id, partitionKey, out T cached))
+                return (new(0, null), cached);
+
             ItemResponse<T> response = await _container.ReadItemAsync<T>(id, BuildPartitionKey(partitionKey));
+            SetPointCache(id, partitionKey, response.Resource);
             return (new(response.RequestCharge, null), response.Resource);
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
@@ -284,7 +305,11 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
     {
         try
         {
+            if (TryGetPointCache(id, [partitionKey], out T cached))
+                return (new(0, null), cached);
+
             ItemResponse<T> response = await _container.ReadItemAsync<T>(id, new(partitionKey));
+            SetPointCache(id, [partitionKey], response.Resource);
             return (new(response.RequestCharge, null), response.Resource);
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
@@ -295,5 +320,54 @@ public class GalaxyBasic<T> : GalaxyCore, IGalaxyBasic<T> where T : class, ICosm
         {
             throw new UniverseException($"A Cosmos DB error occurred. Status: {(int)ex.StatusCode}", ex);
         }
+    }
+
+    private bool TryGetPointCache(string id, IReadOnlyList<string> partitionKeys, out T value)
+    {
+        value = default;
+        DocumentCache cache = DocumentCache;
+        if (cache is null)
+            return false;
+
+        DocumentCacheKey key = cache.CreatePointKey(_databaseName, _containerName, typeof(T), typeof(T), id, partitionKeys);
+        return cache.TryGet(key, out value);
+    }
+
+    private void SetPointCache(T model)
+    {
+        DocumentCache cache = DocumentCache;
+        if (cache is null || model is null)
+            return;
+
+        SetPointCache(model.id, [.. model.PartitionKeys()], model);
+    }
+
+    private void SetPointCache(string id, IReadOnlyList<string> partitionKeys, T model)
+    {
+        DocumentCache cache = DocumentCache;
+        if (cache is null || model is null)
+            return;
+
+        DocumentCacheKey key = cache.CreatePointKey(_databaseName, _containerName, typeof(T), typeof(T), id, partitionKeys);
+        cache.Set(key, DocumentCacheOperation.PointRead, DocumentCacheScopeHash(typeof(T)), model);
+    }
+
+    private void RemovePointCache(string id, IReadOnlyList<string> partitionKeys)
+    {
+        DocumentCache cache = DocumentCache;
+        if (cache is null)
+            return;
+
+        DocumentCacheKey key = cache.CreatePointKey(_databaseName, _containerName, typeof(T), typeof(T), id, partitionKeys);
+        cache.Remove(key);
+    }
+
+    private void ClearQueryCache()
+    {
+        DocumentCache cache = DocumentCache;
+        if (cache is null)
+            return;
+
+        cache.ClearQueries(DocumentCacheScopeHash(typeof(T)));
     }
 }

--- a/code/Universe/GalaxyCore.cs
+++ b/code/Universe/GalaxyCore.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Universe.Builder.Caching;
 
 namespace Universe;
 
@@ -12,6 +13,9 @@ public abstract class GalaxyCore : IDisposable
     internal readonly bool _recordQuery;
     internal readonly bool _allowBulk;
     internal readonly JsonNamingPolicy _namingPolicy;
+    internal readonly string _databaseName;
+    internal readonly string _containerName;
+    internal readonly DocumentCacheOptions _documentCacheOptions;
 
     /// <summary>
     /// Initialize Galaxy core with Cosmos DB connection.
@@ -33,7 +37,7 @@ public abstract class GalaxyCore : IDisposable
     /// in Gravity responses. This may expose sensitive data (PII, filter values). Use only for debugging — never enable in production.
     /// </remarks>
     protected GalaxyCore(CosmosClient client, string database, string container, IReadOnlyList<string> partitionKey, UniverseOptions options, bool recordQueries = false)
-        : this(client, database, container, partitionKey, recordQueries, RequireOptions(options).AutoProvisionContainers)
+        : this(client, database, container, partitionKey, recordQueries, RequireOptions(options))
     {
     }
 
@@ -41,6 +45,23 @@ public abstract class GalaxyCore : IDisposable
         options ?? throw new UniverseException("Universe options are required.");
 
     private GalaxyCore(CosmosClient client, string database, string container, IReadOnlyList<string> partitionKey, bool recordQueries, bool autoProvisionContainers)
+        : this(client, database, container, partitionKey, recordQueries, autoProvisionContainers, documentCacheOptions: null)
+    {
+    }
+
+    private GalaxyCore(CosmosClient client, string database, string container, IReadOnlyList<string> partitionKey, bool recordQueries, UniverseOptions options)
+        : this(client, database, container, partitionKey, recordQueries, options.AutoProvisionContainers, options.DocumentCache)
+    {
+    }
+
+    private GalaxyCore(
+        CosmosClient client,
+        string database,
+        string container,
+        IReadOnlyList<string> partitionKey,
+        bool recordQueries,
+        bool autoProvisionContainers,
+        DocumentCacheOptions documentCacheOptions)
     {
         if (string.IsNullOrWhiteSpace(container))
             throw new UniverseException("Container name is required");
@@ -49,6 +70,9 @@ public abstract class GalaxyCore : IDisposable
             throw new UniverseException("Database name is required");
 
         _recordQuery = recordQueries;
+        _databaseName = database;
+        _containerName = container;
+        _documentCacheOptions = documentCacheOptions;
         if (client.ClientOptions is not null)
         {
             _allowBulk = client.ClientOptions.AllowBulkExecution;
@@ -68,6 +92,11 @@ public abstract class GalaxyCore : IDisposable
             _container = client.GetContainer(database, container);
         }
     }
+
+    internal DocumentCache DocumentCache => _documentCacheOptions?.Cache;
+
+    internal string DocumentCacheScopeHash(Type sourceType)
+        => DocumentCache.CreateScopeHash(_databaseName, _containerName, sourceType);
 
     #region Dispose Pattern
 

--- a/code/Universe/UniverseOptions.cs
+++ b/code/Universe/UniverseOptions.cs
@@ -13,6 +13,11 @@ public sealed class UniverseOptions
     public IQueryStatisticsStorage StatisticsStorage { get; set; }
 
     /// <summary>
+    /// Optional in-memory document cache. Null keeps caching fully disabled.
+    /// </summary>
+    public DocumentCacheOptions DocumentCache { get; private set; }
+
+    /// <summary>
     /// Whether repository construction should create the Cosmos database and container if they do not exist.
     /// Defaults to true for backward compatibility.
     /// </summary>
@@ -36,6 +41,29 @@ public sealed class UniverseOptions
     public UniverseOptions WithAutoProvisioning(bool enabled)
     {
         AutoProvisionContainers = enabled;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables the optional in-memory document cache.
+    /// </summary>
+    /// <param name="timeToLive">Optional cache entry time-to-live. Defaults to 5 minutes.</param>
+    /// <param name="maxEntries">Maximum number of entries retained by the cache. Defaults to 1000.</param>
+    /// <param name="cloneDocuments">Whether cached documents should be cloned before storing and returning. Defaults to true.</param>
+    /// <returns>The same UniverseOptions instance for fluent configuration.</returns>
+    public UniverseOptions WithDocumentCache(TimeSpan? timeToLive = null, int maxEntries = DocumentCacheOptions.DefaultMaxEntries, bool cloneDocuments = true)
+    {
+        DocumentCache = new(timeToLive, maxEntries, cloneDocuments);
+        return this;
+    }
+
+    /// <summary>
+    /// Disables the optional document cache.
+    /// </summary>
+    /// <returns>The same UniverseOptions instance for fluent configuration.</returns>
+    public UniverseOptions WithoutDocumentCache()
+    {
+        DocumentCache = null;
         return this;
     }
 

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -1008,6 +1008,29 @@
             Specialized strategy for vector search queries
             </summary>
         </member>
+        <member name="T:Universe.DocumentCacheOptions">
+            <summary>
+            Optional in-memory document cache configuration.
+            </summary>
+        </member>
+        <member name="F:Universe.DocumentCacheOptions.DefaultTimeToLive">
+            <summary>Default cache entry time-to-live.</summary>
+        </member>
+        <member name="F:Universe.DocumentCacheOptions.DefaultMaxEntries">
+            <summary>Default maximum number of cached entries.</summary>
+        </member>
+        <member name="P:Universe.DocumentCacheOptions.TimeToLive">
+            <summary>How long cached documents remain valid.</summary>
+        </member>
+        <member name="P:Universe.DocumentCacheOptions.MaxEntries">
+            <summary>Maximum number of entries retained by the cache.</summary>
+        </member>
+        <member name="P:Universe.DocumentCacheOptions.CloneDocuments">
+            <summary>Whether cache reads and writes clone document instances.</summary>
+        </member>
+        <member name="M:Universe.DocumentCacheOptions.#ctor(System.Nullable{System.TimeSpan},System.Int32,System.Boolean)">
+            <summary>Create document cache options.</summary>
+        </member>
         <member name="T:Universe.Exception.UniverseException">
             <summary></summary>
         </member>
@@ -1389,6 +1412,11 @@
             Storage backend for query statistics. Defaults to InMemoryStatisticsStorage.
             </summary>
         </member>
+        <member name="P:Universe.UniverseOptions.DocumentCache">
+            <summary>
+            Optional in-memory document cache. Null keeps caching fully disabled.
+            </summary>
+        </member>
         <member name="P:Universe.UniverseOptions.AutoProvisionContainers">
             <summary>
             Whether repository construction should create the Cosmos database and container if they do not exist.
@@ -1406,6 +1434,21 @@
             Disable this in production environments where infrastructure is managed separately.
             </summary>
             <param name="enabled">True to create missing containers automatically; false to use existing containers only.</param>
+            <returns>The same UniverseOptions instance for fluent configuration.</returns>
+        </member>
+        <member name="M:Universe.UniverseOptions.WithDocumentCache(System.Nullable{System.TimeSpan},System.Int32,System.Boolean)">
+            <summary>
+            Enables the optional in-memory document cache.
+            </summary>
+            <param name="timeToLive">Optional cache entry time-to-live. Defaults to 5 minutes.</param>
+            <param name="maxEntries">Maximum number of entries retained by the cache. Defaults to 1000.</param>
+            <param name="cloneDocuments">Whether cached documents should be cloned before storing and returning. Defaults to true.</param>
+            <returns>The same UniverseOptions instance for fluent configuration.</returns>
+        </member>
+        <member name="M:Universe.UniverseOptions.WithoutDocumentCache">
+            <summary>
+            Disables the optional document cache.
+            </summary>
             <returns>The same UniverseOptions instance for fluent configuration.</returns>
         </member>
         <member name="M:Universe.UniverseOptions.WithFilePersistence(System.String)">

--- a/docs/ROADMAP_STATUS.md
+++ b/docs/ROADMAP_STATUS.md
@@ -83,17 +83,25 @@ Implemented:
 - Query tuning recommendations can be rule-based or data-driven from historical samples.
 - File and SQLite statistics persistence are available through `UniverseOptions`.
 
-## Not Complete
-
 ### 2.2 Optional Document Cache And Invalidation Layer
 
-Status: not implemented.
+Status: complete.
 
-The current in-memory components are query-statistics storage and reflection/projection metadata caches. They do not satisfy the roadmap item for an optional cache of frequently accessed documents with invalidation based on document changes.
+Implemented:
 
-Recommended next feature:
+- Document caching is disabled by default and enabled explicitly through `UniverseOptions.WithDocumentCache(...)`.
+- Direct id/partition-key reads and single-document query reads can be cached.
+- Cache keys are hashed and scoped by database, container, source type, result type, and operation kind.
+- Cached values are cloned by default to prevent caller mutation from corrupting cache state.
+- Successful create, modify, remove, bulk create, and bulk modify operations invalidate same-repository single-document query cache entries.
+- Point-read cache entries are updated or removed for local single-document writes where the affected id and partition key are known.
+- Tests use fake Cosmos SDK abstractions and do not require a live Cosmos DB account.
 
-- Add an explicit optional document cache feature with configuration, clear invalidation semantics on create/modify/remove, and tests that do not require live Cosmos DB.
+Caveat:
+
+- The cache is process-local. External writers are handled by the configured time-to-live, not distributed invalidation.
+
+## Not Complete
 
 ### 2.3 RU Budget Management
 


### PR DESCRIPTION
## Summary
- Add an opt-in process-local document cache for point reads and single-document query reads.
- Keep caching disabled by default while exposing UniverseOptions helpers for enabling and disabling the add-on.
- Hash cache keys, clone cached values by default, and invalidate cached single-document reads after local writes.
- Document the cache behavior and mark roadmap item 2.2 complete.