### PR TITLE
release: harden UniverseQuery 3.5.0-preview.2

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -43,3 +43,15 @@ jobs:
       - name: Test
         working-directory: ./code/
         run: dotnet test --filter "Category!=Performance" --verbosity normal
+  package:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.x'
+          dotnet-quality: 'preview'
+      - name: Pack and validate compatibility
+        run: dotnet pack code/Universe/UniverseQuery.csproj -c Release

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -47,9 +47,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '10.x'
           dotnet-quality: 'preview'

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -3,42 +3,65 @@ name: .NET
 on:
   push:
     branches:
-      - 'prod'
-      - 'beta'
+      - prod
+      - beta
 
 permissions:
   contents: read
 
+concurrency:
+  group: nuget-publish-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   publish:
-    name: Build, Pack & Publish NuGet
+    name: Build, Test, Pack & Publish NuGet
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    
-    # Use specific .NET Version
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: 10.x
-        
-    # Restore
-    - name: Restore dependencies
-      run: |
-        cd ./code
-        dotnet restore
-      
-    # Build
-    - name: Build
-      run: |
-        cd ./code
-        dotnet build --no-restore
+      - uses: actions/checkout@v6
 
-    # Pack
-    - name: Pack
-      run:
-        dotnet pack code/Universe/UniverseQuery.csproj -c Release
-      
-    # Publish
-    - name: Publish
-      run: dotnet nuget push /home/runner/work/universe/universe/code/Universe/bin/Release/UniverseQuery.*.nupkg --api-key ${{secrets.NUGET_KEY}} --source "https://api.nuget.org/v3/index.json" --skip-duplicate
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.x
+
+      - name: Validate branch version
+        shell: bash
+        run: |
+          package_version=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' VERSION)
+          project_version=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' code/Universe/UniverseQuery.csproj)
+          if [[ -z "$package_version" ]]; then
+            echo "VERSION does not contain a package version."
+            exit 1
+          fi
+          if [[ "$package_version" != "$project_version" ]]; then
+            echo "VERSION and UniverseQuery.csproj must contain the same package version."
+            exit 1
+          fi
+          if [[ "$GITHUB_REF_NAME" == "beta" && "$package_version" != *-* ]]; then
+            echo "The beta branch requires a prerelease package version."
+            exit 1
+          fi
+          if [[ "$GITHUB_REF_NAME" == "prod" && "$package_version" == *-* ]]; then
+            echo "The prod branch requires a stable package version."
+            exit 1
+          fi
+          echo "PACKAGE_VERSION=$package_version" >> "$GITHUB_ENV"
+
+      - name: Restore dependencies
+        working-directory: ./code
+        run: dotnet restore
+
+      - name: Build release
+        working-directory: ./code
+        run: dotnet build -c Release --no-restore
+
+      - name: Test release
+        working-directory: ./code
+        run: dotnet test -c Release --no-build --filter "Category!=Performance" --verbosity normal
+
+      - name: Pack and validate compatibility
+        run: dotnet pack code/Universe/UniverseQuery.csproj -c Release --no-build --no-restore
+
+      - name: Publish
+        run: dotnet nuget push "code/Universe/bin/Release/UniverseQuery.${PACKAGE_VERSION}.nupkg" --api-key ${{ secrets.NUGET_KEY }} --source "https://api.nuget.org/v3/index.json"

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -18,10 +18,10 @@ jobs:
     name: Build, Test, Pack & Publish NuGet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: 10.x
 

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -201,14 +201,22 @@ The test project is the fastest feedback loop for library behavior that does not
 
 ```text
 code/Universe.Tests/
+|-- Batch/
+|   |-- BatchBuilderTests.cs
+|   |-- BatchExecutionTests.cs
+|   `-- LegacyInterfaceCompatibilityTests.cs
 |-- Builder/
 |   |-- NamingPolicyQueryTests.cs
 |   |-- OrbitQueryTests.cs
 |   |-- QueryTypeDetectorTests.cs
 |   `-- ProjectionSelectTests.cs
+|-- Caching/
+|   |-- DocumentCacheRepositoryTests.cs
+|   `-- DocumentCacheTests.cs
 |-- Extensions/
 |   `-- PartitionKeyExtensionTests.cs
 |-- Helpers/
+|   |-- InMemoryCosmosContainer.cs
 |   `-- TestStatisticsFactory.cs
 |-- Storage/
 |   |-- FileStatisticsStorageTests.cs

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -974,6 +974,8 @@ Example sequencing:
 - `Storage/SqliteStatisticsStorageTests.cs`: SQLite persistence behavior.
 - `Caching/DocumentCacheTests.cs`: cache key hashing, TTL, eviction, cloning, and query-key normalization behavior.
 - `Caching/DocumentCacheRepositoryTests.cs`: opt-in repository cache behavior using fake Cosmos SDK abstractions.
+- `Batch/BatchExecutionTests.cs`: in-memory atomic/bulk execution, rollback, ETags, chunking, concurrency, partial success, cancellation, and cache behavior.
+- `Batch/LegacyInterfaceCompatibilityTests.cs`: default-interface compatibility for implementations built around the pre-batch `IGalaxyBasic<T>` contract.
 - `Tuner/QueryTunerTests.cs`: recommendation and persistence behavior.
 - `Tuner/QueryTunerPerformanceTests.cs`: tuner performance checks.
 - `Helpers/TestStatisticsFactory.cs`: shared test statistics builders.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ BulkExecutionResult<MyModel> bulk = await galaxy
 
 Atomic and bulk results include ordered per-operation status, ETag, request charge allocation, operation kind, id, and partition key. Service-side failures—including stale ETags (`412`)—are returned as structured results. Invalid input and transport failures throw `UniverseException`; cancellation throws `OperationCanceledException`. Patch predicates accept only typed member selectors and scalar values, so callers cannot inject raw Cosmos SQL.
 
+The transactional execution suite uses a deterministic in-memory Cosmos harness to verify atomic rollback, optimistic concurrency, chunking, bounded cross-partition concurrency, partial success, cancellation, request options, and cache invalidation. The test and release workflows do not create or connect to Cosmos DB resources.
+
 ### Deleting Documents
 
 ```csharp

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-<Version>3.5.0-preview.1</Version>
+<Version>3.5.0-preview.2</Version>

--- a/code/Universe.Tests/Batch/BatchExecutionTests.cs
+++ b/code/Universe.Tests/Batch/BatchExecutionTests.cs
@@ -1,0 +1,282 @@
+using System.Net;
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Azure.Cosmos;
+using Universe.Attributes;
+using Universe.Builder.Options;
+using Universe.Exception;
+using Universe.Extensions;
+using Universe.Interfaces;
+using Universe.Response;
+using Universe.Tests.Helpers;
+using Xunit;
+
+namespace Universe.Tests.Batch;
+
+public sealed class BatchExecutionTests
+{
+    [Fact]
+    public async Task Atomic_MixedOperationsCommitInOrderAndUpdateCache()
+    {
+        InMemoryCosmosContainer<BatchEntity> container = new();
+        BatchEntity replace = Entity("replace", "tenant-1", 1, "queued");
+        BatchEntity patch = Entity("patch", "tenant-1", 2, "active");
+        BatchEntity delete = Entity("delete", "tenant-1", 3, "obsolete");
+        container.Seed(replace, "etag-replace");
+        container.Seed(patch, "etag-patch");
+        container.Seed(delete, "etag-delete");
+        container.PatchConditionEvaluator = (model, predicate) =>
+            model.Status == "active" && predicate == "FROM c WHERE c[\"status\"] = \"active\"";
+        TestGalaxy repository = CreateRepository(container, cache: true);
+        await repository.PointGet(patch.id, patch.TenantId);
+        BatchEntity create = Entity("create", "tenant-1", 4, "new");
+        replace.Quantity = 10;
+
+        AtomicBatchResult<BatchEntity> result = await repository.Atomic("tenant-1")
+            .Create(create)
+            .Replace(replace, "etag-replace")
+            .Patch(
+                patch.id,
+                operations => operations.Increment(entity => entity.Quantity, 5),
+                "etag-patch",
+                condition => condition.Equal(entity => entity.Status, "active"))
+            .Delete(delete.id, "etag-delete")
+            .ExecuteAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        Assert.Equal(5, result.Gravity.RU);
+        Assert.Equal(
+            [BatchOperationKind.Create, BatchOperationKind.Replace, BatchOperationKind.Patch, BatchOperationKind.Delete],
+            result.Operations.Select(operation => operation.Kind));
+        Assert.All(result.Operations.Take(3), operation => Assert.False(string.IsNullOrWhiteSpace(operation.ETag)));
+        Assert.Equal(4, result.Operations.Count);
+
+        Assert.Equal(4, container.Find(create).Value.Model.Quantity);
+        Assert.Equal(10, container.Find(replace).Value.Model.Quantity);
+        Assert.Equal(7, container.Find(patch).Value.Model.Quantity);
+        Assert.Null(container.Find(delete));
+
+        InMemoryBatchExecution<BatchEntity> execution = Assert.Single(container.Executions);
+        Assert.Equal(HttpStatusCode.OK, execution.StatusCode);
+        Assert.Equal(5, execution.RequestCharge);
+        Assert.Equal(result.Operations.Select(operation => operation.StatusCode), execution.Outcomes.Select(outcome => outcome.StatusCode));
+        InMemoryBatchOperation<BatchEntity> patchOperation = execution.Operations[2];
+        Assert.Equal("etag-patch", patchOperation.IfMatchETag);
+        Assert.Equal("FROM c WHERE c[\"status\"] = \"active\"", patchOperation.FilterPredicate);
+        Assert.IsType<TransactionalBatchPatchItemRequestOptions>(patchOperation.RequestOptions);
+
+        (Gravity createCache, BatchEntity cachedCreate) = await repository.PointGet(create.id, create.TenantId);
+        (Gravity replaceCache, BatchEntity cachedReplace) = await repository.PointGet(replace.id, replace.TenantId);
+        (Gravity patchRead, BatchEntity patched) = await repository.PointGet(patch.id, patch.TenantId);
+        Assert.Equal(0, createCache.RU);
+        Assert.Equal(0, replaceCache.RU);
+        Assert.Equal(1, patchRead.RU);
+        Assert.Equal(4, cachedCreate.Quantity);
+        Assert.Equal(10, cachedReplace.Quantity);
+        Assert.Equal(7, patched.Quantity);
+    }
+
+    [Fact]
+    public async Task Atomic_FailedPatchConditionRollsBackEarlierOperations()
+    {
+        InMemoryCosmosContainer<BatchEntity> container = new();
+        BatchEntity replace = Entity("replace", "tenant-1", 1, "queued");
+        BatchEntity patch = Entity("patch", "tenant-1", 2, "inactive");
+        container.Seed(replace, "etag-replace");
+        container.Seed(patch, "etag-patch");
+        container.PatchConditionEvaluator = (model, predicate) =>
+            model.Status == "active" && predicate == "FROM c WHERE c[\"status\"] = \"active\"";
+        TestGalaxy repository = CreateRepository(container);
+        replace.Quantity = 11;
+
+        AtomicBatchResult<BatchEntity> result = await repository.Atomic("tenant-1")
+            .Replace(replace, "etag-replace")
+            .Patch(
+                patch.id,
+                operations => operations.Increment(entity => entity.Quantity, 5),
+                "etag-patch",
+                condition => condition.Equal(entity => entity.Status, "active"))
+            .ExecuteAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(HttpStatusCode.PreconditionFailed, result.StatusCode);
+        Assert.Equal(HttpStatusCode.FailedDependency, result.Operations[0].StatusCode);
+        Assert.Equal(HttpStatusCode.PreconditionFailed, result.Operations[1].StatusCode);
+        Assert.Equal(1, container.Find(replace).Value.Model.Quantity);
+        Assert.Equal(2, container.Find(patch).Value.Model.Quantity);
+    }
+
+    [Fact]
+    public async Task Atomic_StaleETagRollsBackAndPreservesCache()
+    {
+        InMemoryCosmosContainer<BatchEntity> container = new();
+        BatchEntity first = Entity("first", "tenant-1", 1, "active");
+        BatchEntity second = Entity("second", "tenant-1", 2, "active");
+        container.Seed(first, "etag-first");
+        container.Seed(second, "etag-second");
+        TestGalaxy repository = CreateRepository(container, cache: true);
+        await repository.PointGet(first.id, first.TenantId);
+        first.Quantity = 11;
+        second.Quantity = 22;
+
+        AtomicBatchResult<BatchEntity> result = await repository.Atomic("tenant-1")
+            .Replace(first, "etag-first")
+            .Replace(second, "stale-etag")
+            .ExecuteAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(HttpStatusCode.PreconditionFailed, result.StatusCode);
+        Assert.Equal(HttpStatusCode.FailedDependency, result.Operations[0].StatusCode);
+        Assert.Equal(HttpStatusCode.PreconditionFailed, result.Operations[1].StatusCode);
+        Assert.Equal(1, container.Find(first).Value.Model.Quantity);
+        Assert.Equal(2, container.Find(second).Value.Model.Quantity);
+
+        (Gravity cachedGravity, BatchEntity cached) = await repository.PointGet(first.id, first.TenantId);
+        Assert.Equal(0, cachedGravity.RU);
+        Assert.Equal(1, cached.Quantity);
+    }
+
+    [Fact]
+    public async Task Bulk_ChunksAtOneHundredAndPreservesPartitionOrder()
+    {
+        InMemoryCosmosContainer<BatchEntity> container = new();
+        TestGalaxy repository = CreateRepository(container);
+        BulkBatch<BatchEntity> batch = repository.Bulk();
+        for (int index = 0; index < 205; index++)
+            batch.Create(Entity($"item-{index:D3}", "tenant-1", index, "new"));
+
+        BulkExecutionResult<BatchEntity> result = await batch.ExecuteAsync(
+            new() { MaxConcurrency = 4 },
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(205, result.SucceededCount);
+        Assert.Equal([100, 100, 5], container.Executions.Select(execution => execution.Operations.Count));
+        Assert.Equal(
+            Enumerable.Range(0, 205).Select(index => $"item-{index:D3}"),
+            container.Executions.SelectMany(execution => execution.Operations).Select(operation => operation.Id));
+        Assert.Equal(1, container.MaxConcurrentExecutions);
+    }
+
+    [Fact]
+    public async Task Bulk_RespectsConcurrencyAndReportsCrossPartitionPartialSuccess()
+    {
+        InMemoryCosmosContainer<BatchEntity> container = new() { ExecutionDelay = TimeSpan.FromMilliseconds(40) };
+        BatchEntity duplicate = Entity("duplicate", "tenant-bad", 1, "existing");
+        container.Seed(duplicate);
+        TestGalaxy repository = CreateRepository(container, cache: true);
+        await repository.PointGet(duplicate.id, duplicate.TenantId);
+        BulkBatch<BatchEntity> batch = repository.Bulk()
+            .Create(Entity("good-a", "tenant-a", 1, "new"))
+            .Create(duplicate)
+            .Create(Entity("good-c", "tenant-c", 1, "new"))
+            .Create(Entity("good-d", "tenant-d", 1, "new"));
+
+        BulkExecutionResult<BatchEntity> result = await batch.ExecuteAsync(
+            new() { MaxConcurrency = 2 },
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.IsPartialSuccess);
+        Assert.Equal(3, result.SucceededCount);
+        Assert.Equal(1, result.FailedCount);
+        Assert.Equal(HttpStatusCode.Conflict, result.StatusCode);
+        Assert.Equal(2, container.MaxConcurrentExecutions);
+        Assert.Equal(4, container.Executions.Count);
+
+        (Gravity goodCache, BatchEntity good) = await repository.PointGet("good-a", "tenant-a");
+        (Gravity duplicateCache, BatchEntity unchanged) = await repository.PointGet(duplicate.id, duplicate.TenantId);
+        Assert.Equal(0, goodCache.RU);
+        Assert.Equal(0, duplicateCache.RU);
+        Assert.Equal("new", good.Status);
+        Assert.Equal("existing", unchanged.Status);
+    }
+
+    [Fact]
+    public async Task Batch_PreCancellationPerformsNoOperations()
+    {
+        InMemoryCosmosContainer<BatchEntity> container = new();
+        TestGalaxy repository = CreateRepository(container);
+        using CancellationTokenSource cancellation = new();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => repository.Bulk()
+            .Create(Entity("cancelled", "tenant-1", 1, "new"))
+            .ExecuteAsync(cancellationToken: cancellation.Token));
+
+        Assert.Empty(container.Executions);
+        Assert.Null(container.Find(Entity("cancelled", "tenant-1", 1, "new")));
+    }
+
+    [Fact]
+    public async Task Batch_TransportFailureUsesUniverseExceptionContract()
+    {
+        InMemoryCosmosContainer<BatchEntity> container = new();
+        container.FailNextExecution(new CosmosException(
+            "transport failure",
+            HttpStatusCode.ServiceUnavailable,
+            0,
+            "in-memory",
+            0));
+        TestGalaxy repository = CreateRepository(container);
+
+        UniverseException exception = await Assert.ThrowsAsync<UniverseException>(() => repository.Atomic("tenant-1")
+            .Create(Entity("transport", "tenant-1", 1, "new"))
+            .ExecuteAsync(TestContext.Current.CancellationToken));
+
+        Assert.IsType<CosmosException>(exception.InnerException);
+        Assert.Empty(container.Executions);
+    }
+
+    private static TestGalaxy CreateRepository(InMemoryCosmosContainer<BatchEntity> container, bool cache = false)
+    {
+        UniverseOptions options = new UniverseOptions().WithAutoProvisioning(false);
+        if (cache)
+            options.WithDocumentCache();
+        return new(container, options);
+    }
+
+    private static BatchEntity Entity(string id, string tenantId, int quantity, string status)
+        => new() { id = id, TenantId = tenantId, Quantity = quantity, Status = status };
+
+    private sealed class TestGalaxy : Galaxy<BatchEntity>
+    {
+        public TestGalaxy(InMemoryCosmosContainer<BatchEntity> container, UniverseOptions options)
+            : base(CreateClient(), "database", "container", typeof(BatchEntity).BuildPartitionKey(), options)
+        {
+            FieldInfo containerField = typeof(GalaxyCore)
+                .GetField("_container", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("GalaxyCore._container was not found.");
+            containerField.SetValue(this, container);
+        }
+
+        public AtomicBatch<BatchEntity> Atomic(params string[] partitionKeys)
+            => ((IGalaxyBasic<BatchEntity>)this).Atomic(partitionKeys);
+
+        public BulkBatch<BatchEntity> Bulk()
+            => ((IGalaxyBasic<BatchEntity>)this).Bulk();
+
+        public Task<(Gravity, BatchEntity)> PointGet(string id, string tenantId)
+            => ((IGalaxyBasic<BatchEntity>)this).Get(id, tenantId);
+
+        private static CosmosClient CreateClient()
+            => new(
+                "https://localhost:8081",
+                Convert.ToBase64String(new byte[64]),
+                new CosmosClientOptions
+                {
+                    AllowBulkExecution = true,
+                    Serializer = new UniverseSerializer(JsonNamingPolicy.CamelCase)
+                });
+    }
+
+    private sealed record BatchEntity : CosmicEntity
+    {
+        [PartitionKey]
+        public string TenantId { get; set; }
+
+        public int Quantity { get; set; }
+        public string Status { get; set; }
+    }
+}

--- a/code/Universe.Tests/Batch/BatchExecutionTests.cs
+++ b/code/Universe.Tests/Batch/BatchExecutionTests.cs
@@ -162,7 +162,7 @@ public sealed class BatchExecutionTests
     [Fact]
     public async Task Bulk_RespectsConcurrencyAndReportsCrossPartitionPartialSuccess()
     {
-        InMemoryCosmosContainer<BatchEntity> container = new() { ExecutionDelay = TimeSpan.FromMilliseconds(40) };
+        InMemoryCosmosContainer<BatchEntity> container = new() { ExecutionReleaseThreshold = 2 };
         BatchEntity duplicate = Entity("duplicate", "tenant-bad", 1, "existing");
         container.Seed(duplicate);
         TestGalaxy repository = CreateRepository(container, cache: true);

--- a/code/Universe.Tests/Batch/LegacyInterfaceCompatibilityTests.cs
+++ b/code/Universe.Tests/Batch/LegacyInterfaceCompatibilityTests.cs
@@ -1,0 +1,61 @@
+using Universe.Interfaces;
+using Universe.Response;
+using Xunit;
+
+namespace Universe.Tests.Batch;
+
+public sealed class LegacyInterfaceCompatibilityTests
+{
+    [Fact]
+    public async Task LegacyImplementation_ExistingOperationsRemainCallable()
+    {
+        IGalaxyBasic<LegacyEntity> legacy = new LegacyGalaxy();
+        LegacyEntity entity = new() { id = "legacy-id" };
+
+        (Gravity gravity, string id) = await legacy.Create(entity);
+
+        Assert.Equal("legacy-id", id);
+        Assert.Equal(1, gravity.RU);
+    }
+
+    [Fact]
+    public void LegacyImplementation_NewBatchOperationsFailClearly()
+    {
+        IGalaxyBasic<LegacyEntity> legacy = new LegacyGalaxy();
+
+        NotSupportedException atomic = Assert.Throws<NotSupportedException>(() => legacy.Atomic("tenant-1"));
+        NotSupportedException bulk = Assert.Throws<NotSupportedException>(() => legacy.Bulk());
+
+        Assert.Contains("atomic batch operations", atomic.Message);
+        Assert.Contains("bulk batch operations", bulk.Message);
+    }
+
+    private sealed class LegacyGalaxy : IGalaxyBasic<LegacyEntity>
+    {
+        public Task<(Gravity g, string t)> Create(LegacyEntity model)
+            => Task.FromResult<(Gravity, string)>((new(1, null), model.id));
+
+        public Task<Gravity> Create(IReadOnlyList<LegacyEntity> models)
+            => Task.FromResult<Gravity>(new(models.Count, null));
+
+        public Task<(Gravity g, LegacyEntity T)> Modify(LegacyEntity model)
+            => Task.FromResult<(Gravity, LegacyEntity)>((new(1, null), model));
+
+        public Task<Gravity> Modify(IReadOnlyList<LegacyEntity> models)
+            => Task.FromResult<Gravity>(new(models.Count, null));
+
+        public Task<Gravity> Remove(string id, string partitionKey)
+            => Task.FromResult<Gravity>(new(1, null));
+
+        public Task<Gravity> Remove(string id, params string[] partitionKey)
+            => Task.FromResult<Gravity>(new(1, null));
+
+        public Task<(Gravity g, LegacyEntity T)> Get(string id, string partitionKey)
+            => Task.FromResult<(Gravity, LegacyEntity)>((new(1, null), new() { id = id }));
+
+        public Task<(Gravity g, LegacyEntity T)> Get(string id, params string[] partitionKey)
+            => Task.FromResult<(Gravity, LegacyEntity)>((new(1, null), new() { id = id }));
+    }
+
+    private sealed record LegacyEntity : CosmicEntity;
+}

--- a/code/Universe.Tests/Caching/DocumentCacheRepositoryTests.cs
+++ b/code/Universe.Tests/Caching/DocumentCacheRepositoryTests.cs
@@ -66,25 +66,6 @@ public sealed class DocumentCacheRepositoryTests
     }
 
     [Fact]
-    public async Task AtomicCreate_ExecutesOneBatchAndUpdatesPointCacheAfterCommit()
-    {
-        FakeContainer container = new();
-        TestGalaxy repo = new(container, new UniverseOptions().WithAutoProvisioning(false).WithDocumentCache());
-        CacheEntity entity = new() { TenantId = "tenant-1", Name = "atomic" };
-
-        AtomicBatchResult<CacheEntity> result = await repo.Atomic("tenant-1").Create(entity).ExecuteAsync(TestContext.Current.CancellationToken);
-        (Gravity cachedGravity, CacheEntity cached) = await repo.PointGet(entity.id, "tenant-1");
-
-        Assert.True(result.Succeeded);
-        Assert.Single(result.Operations);
-        Assert.Equal(3.5, result.Gravity.RU);
-        Assert.Equal(1, container.TransactionalBatchCalls);
-        Assert.Equal(0, cachedGravity.RU);
-        Assert.Equal("atomic", cached.Name);
-        Assert.Equal(0, container.ReadItemCalls);
-    }
-
-    [Fact]
     public async Task QueryGet_CacheEnabled_UsesStableKeyAcrossGeneratedCatalystIds()
     {
         FakeContainer container = new()
@@ -200,9 +181,6 @@ public sealed class DocumentCacheRepositoryTests
         public Task<Gravity> RemoveEntity(string id, string tenantId)
             => ((IGalaxyBasic<CacheEntity>)this).Remove(id, tenantId);
 
-        public AtomicBatch<CacheEntity> Atomic(string tenantId)
-            => ((IGalaxyBasic<CacheEntity>)this).Atomic(tenantId);
-
         private static CosmosClient CreateClient()
             => new(
                 "https://localhost:8081",
@@ -225,7 +203,6 @@ public sealed class DocumentCacheRepositoryTests
         public IReadOnlyList<CacheEntity> QueryItems { get; set; } = [];
         public int ReadItemCalls { get; private set; }
         public int QueryCalls { get; private set; }
-        public int TransactionalBatchCalls { get; private set; }
 
         public override string Id => "container";
         public override Database Database => throw new NotSupportedException();
@@ -254,10 +231,7 @@ public sealed class DocumentCacheRepositoryTests
             => Task.FromResult<ItemResponse<T>>(new FakeItemResponse<T>(item, 5.5));
 
         public override TransactionalBatch CreateTransactionalBatch(PartitionKey partitionKey)
-        {
-            TransactionalBatchCalls++;
-            return new FakeTransactionalBatch();
-        }
+            => throw new NotSupportedException();
 
         public override Task<ContainerResponse> ReadContainerAsync(ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public override Task<ResponseMessage> ReadContainerStreamAsync(ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
@@ -331,25 +305,4 @@ public sealed class DocumentCacheRepositoryTests
         public override IEnumerator<T> GetEnumerator() => items.GetEnumerator();
     }
 
-    private sealed class FakeTransactionalBatch : TransactionalBatch
-    {
-        public override TransactionalBatch CreateItem<T>(T item, TransactionalBatchItemRequestOptions requestOptions = null) => this;
-        public override TransactionalBatch CreateItemStream(Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null) => this;
-        public override TransactionalBatch ReadItem(string id, TransactionalBatchItemRequestOptions requestOptions = null) => this;
-        public override TransactionalBatch UpsertItem<T>(T item, TransactionalBatchItemRequestOptions requestOptions = null) => this;
-        public override TransactionalBatch UpsertItemStream(Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null) => this;
-        public override TransactionalBatch ReplaceItem<T>(string id, T item, TransactionalBatchItemRequestOptions requestOptions = null) => this;
-        public override TransactionalBatch ReplaceItemStream(string id, Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null) => this;
-        public override TransactionalBatch DeleteItem(string id, TransactionalBatchItemRequestOptions requestOptions = null) => this;
-        public override TransactionalBatch PatchItem(string id, IReadOnlyList<PatchOperation> patchOperations, TransactionalBatchPatchItemRequestOptions requestOptions = null) => this;
-        public override Task<TransactionalBatchResponse> ExecuteAsync(CancellationToken cancellationToken = default) => Task.FromResult<TransactionalBatchResponse>(new FakeTransactionalBatchResponse());
-        public override Task<TransactionalBatchResponse> ExecuteAsync(TransactionalBatchRequestOptions requestOptions, CancellationToken cancellationToken = default) => Task.FromResult<TransactionalBatchResponse>(new FakeTransactionalBatchResponse());
-    }
-
-    private sealed class FakeTransactionalBatchResponse : TransactionalBatchResponse
-    {
-        public override bool IsSuccessStatusCode => true;
-        public override HttpStatusCode StatusCode => HttpStatusCode.OK;
-        public override double RequestCharge => 3.5;
-    }
 }

--- a/code/Universe.Tests/Helpers/InMemoryCosmosContainer.cs
+++ b/code/Universe.Tests/Helpers/InMemoryCosmosContainer.cs
@@ -19,6 +19,7 @@ internal sealed class InMemoryCosmosContainer<T> : Container where T : class, IC
 
     private readonly object _sync = new();
     private readonly Dictionary<string, StoredDocument> _documents = [];
+    private readonly TaskCompletionSource _executionGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly ConcurrentQueue<System.Exception> _transportFailures = [];
     private int _activeExecutions;
     private int _etagSequence;
@@ -27,6 +28,7 @@ internal sealed class InMemoryCosmosContainer<T> : Container where T : class, IC
 
     internal List<InMemoryBatchExecution<T>> Executions { get; } = [];
     internal TimeSpan ExecutionDelay { get; set; }
+    internal int ExecutionReleaseThreshold { get; set; } = 1;
     internal Func<T, string, bool> PatchConditionEvaluator { get; set; }
     internal int MaxConcurrentExecutions => _maxConcurrentExecutions;
     internal int ReadItemCalls => _readItemCalls;
@@ -71,6 +73,10 @@ internal sealed class InMemoryCosmosContainer<T> : Container where T : class, IC
         UpdateMaxConcurrency(active);
         try
         {
+            if (active >= ExecutionReleaseThreshold)
+                _executionGate.TrySetResult();
+            await _executionGate.Task.WaitAsync(cancellationToken);
+
             if (ExecutionDelay > TimeSpan.Zero)
                 await Task.Delay(ExecutionDelay, cancellationToken);
 

--- a/code/Universe.Tests/Helpers/InMemoryCosmosContainer.cs
+++ b/code/Universe.Tests/Helpers/InMemoryCosmosContainer.cs
@@ -1,0 +1,484 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Scripts;
+using Universe.Extensions;
+using Universe.Interfaces;
+
+namespace Universe.Tests.Helpers;
+
+internal sealed class InMemoryCosmosContainer<T> : Container where T : class, ICosmicEntity
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly object _sync = new();
+    private readonly Dictionary<string, StoredDocument> _documents = [];
+    private readonly ConcurrentQueue<System.Exception> _transportFailures = [];
+    private int _activeExecutions;
+    private int _etagSequence;
+    private int _maxConcurrentExecutions;
+    private int _readItemCalls;
+
+    internal List<InMemoryBatchExecution<T>> Executions { get; } = [];
+    internal TimeSpan ExecutionDelay { get; set; }
+    internal Func<T, string, bool> PatchConditionEvaluator { get; set; }
+    internal int MaxConcurrentExecutions => _maxConcurrentExecutions;
+    internal int ReadItemCalls => _readItemCalls;
+
+    public override string Id => "in-memory-container";
+    public override Database Database => throw new NotSupportedException();
+    public override Conflicts Conflicts => throw new NotSupportedException();
+    public override Scripts Scripts => throw new NotSupportedException();
+
+    internal void Seed(T model, string eTag = "etag-seed")
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        lock (_sync)
+            _documents[DocumentKey(model.BuildPartitionKey().ToString(), model.id)] = new(Clone(model), eTag);
+    }
+
+    internal (T Model, string ETag)? Find(T model)
+        => Find(model.id, model.BuildPartitionKey().ToString());
+
+    internal (T Model, string ETag)? Find(string id, string partitionKey)
+    {
+        lock (_sync)
+        {
+            return _documents.TryGetValue(DocumentKey(partitionKey, id), out StoredDocument stored)
+                ? (Clone(stored.Model), stored.ETag)
+                : null;
+        }
+    }
+
+    internal void FailNextExecution(System.Exception exception) => _transportFailures.Enqueue(exception);
+
+    public override TransactionalBatch CreateTransactionalBatch(PartitionKey partitionKey)
+        => new InMemoryTransactionalBatch<T>(this, partitionKey.ToString());
+
+    internal async Task<TransactionalBatchResponse> ExecuteAsync(
+        string partitionKey,
+        IReadOnlyList<InMemoryBatchOperation<T>> operations,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        int active = Interlocked.Increment(ref _activeExecutions);
+        UpdateMaxConcurrency(active);
+        try
+        {
+            if (ExecutionDelay > TimeSpan.Zero)
+                await Task.Delay(ExecutionDelay, cancellationToken);
+
+            if (_transportFailures.TryDequeue(out System.Exception transportFailure))
+                throw transportFailure;
+
+            lock (_sync)
+            {
+                Dictionary<string, StoredDocument> snapshot = _documents.ToDictionary(
+                    pair => pair.Key,
+                    pair => new StoredDocument(Clone(pair.Value.Model), pair.Value.ETag));
+                List<InMemoryOperationOutcome> outcomes = [];
+                int failureIndex = -1;
+
+                for (int index = 0; index < operations.Count; index++)
+                {
+                    InMemoryOperationOutcome outcome = Apply(snapshot, partitionKey, operations[index]);
+                    outcomes.Add(outcome);
+                    if (!outcome.IsSuccessStatusCode)
+                    {
+                        failureIndex = index;
+                        break;
+                    }
+                }
+
+                if (failureIndex >= 0)
+                {
+                    outcomes = operations.Select((_, index) => index == failureIndex
+                        ? outcomes[failureIndex]
+                        : new InMemoryOperationOutcome(HttpStatusCode.FailedDependency, null)).ToList();
+                }
+                else
+                {
+                    _documents.Clear();
+                    foreach ((string key, StoredDocument value) in snapshot)
+                        _documents[key] = value;
+                }
+
+                double requestCharge = operations.Count * 1.25;
+                HttpStatusCode statusCode = failureIndex < 0 ? HttpStatusCode.OK : outcomes[failureIndex].StatusCode;
+                InMemoryBatchExecution<T> execution = new(
+                    partitionKey,
+                    operations.ToArray(),
+                    failureIndex < 0,
+                    statusCode,
+                    requestCharge,
+                    outcomes.ToArray());
+                Executions.Add(execution);
+                return new InMemoryTransactionalBatchResponse(statusCode, requestCharge, outcomes);
+            }
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _activeExecutions);
+        }
+    }
+
+    public override Task<ItemResponse<TItem>> ReadItemAsync<TItem>(
+        string id,
+        PartitionKey partitionKey,
+        ItemRequestOptions requestOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Interlocked.Increment(ref _readItemCalls);
+        (T Model, string ETag)? found = Find(id, partitionKey.ToString());
+        if (found is null)
+            throw new CosmosException("Not found", HttpStatusCode.NotFound, 0, "in-memory", 0);
+
+        return Task.FromResult<ItemResponse<TItem>>(new InMemoryItemResponse<TItem>(
+            (TItem)(object)found.Value.Model,
+            found.Value.ETag,
+            HttpStatusCode.OK,
+            1));
+    }
+
+    private InMemoryOperationOutcome Apply(
+        Dictionary<string, StoredDocument> snapshot,
+        string partitionKey,
+        InMemoryBatchOperation<T> operation)
+    {
+        string key = DocumentKey(partitionKey, operation.Id);
+        snapshot.TryGetValue(key, out StoredDocument current);
+
+        if (operation.Kind is InMemoryBatchOperationKind.Create)
+        {
+            if (current is not null)
+                return new(HttpStatusCode.Conflict, null);
+
+            string eTag = NextETag();
+            snapshot[key] = new(Clone(operation.Model), eTag);
+            return new(HttpStatusCode.Created, eTag);
+        }
+
+        if (current is null)
+            return new(HttpStatusCode.NotFound, null);
+        if (!string.IsNullOrWhiteSpace(operation.IfMatchETag) && operation.IfMatchETag != current.ETag)
+            return new(HttpStatusCode.PreconditionFailed, current.ETag);
+        if (operation.RequestOptions is TransactionalBatchItemRequestOptions requestOptions &&
+            !string.IsNullOrWhiteSpace(requestOptions.IfNoneMatchEtag))
+            return new(HttpStatusCode.BadRequest, current.ETag);
+        if (operation.Kind is InMemoryBatchOperationKind.Patch && !string.IsNullOrWhiteSpace(operation.FilterPredicate))
+        {
+            if (PatchConditionEvaluator is null)
+                return new(HttpStatusCode.BadRequest, current.ETag);
+            if (!PatchConditionEvaluator(Clone(current.Model), operation.FilterPredicate))
+                return new(HttpStatusCode.PreconditionFailed, current.ETag);
+        }
+
+        if (operation.Kind is InMemoryBatchOperationKind.Delete)
+        {
+            snapshot.Remove(key);
+            return new(HttpStatusCode.NoContent, null);
+        }
+
+        string nextETag = NextETag();
+        T next;
+        try
+        {
+            next = operation.Kind is InMemoryBatchOperationKind.Replace
+                ? Clone(operation.Model)
+                : ApplyPatch(current.Model, operation.PatchOperations);
+        }
+        catch (InvalidOperationException)
+        {
+            return new(HttpStatusCode.BadRequest, current.ETag);
+        }
+        catch (NotSupportedException)
+        {
+            return new(HttpStatusCode.BadRequest, current.ETag);
+        }
+        snapshot[key] = new(next, nextETag);
+        return new(HttpStatusCode.OK, nextETag);
+    }
+
+    private static T ApplyPatch(T model, IReadOnlyList<PatchOperation> operations)
+    {
+        JsonNode root = JsonSerializer.SerializeToNode(model, SerializerOptions)
+            ?? throw new InvalidOperationException("Unable to serialize an in-memory document.");
+
+        foreach (PatchOperation operation in operations)
+        {
+            string[] segments = operation.Path.Split('/', StringSplitOptions.RemoveEmptyEntries)
+                .Select(segment => segment.Replace("~1", "/", StringComparison.Ordinal).Replace("~0", "~", StringComparison.Ordinal))
+                .ToArray();
+            JsonObject parent = NavigateToParent(root, segments);
+            string property = segments[^1];
+            object value = PatchValue(operation);
+
+            switch (operation.OperationType)
+            {
+                case PatchOperationType.Add:
+                case PatchOperationType.Set:
+                    parent[property] = JsonSerializer.SerializeToNode(value, value?.GetType() ?? typeof(object));
+                    break;
+                case PatchOperationType.Replace:
+                    if (!parent.ContainsKey(property))
+                        throw new InvalidOperationException($"Patch replace target '{operation.Path}' does not exist.");
+                    parent[property] = JsonSerializer.SerializeToNode(value, value?.GetType() ?? typeof(object));
+                    break;
+                case PatchOperationType.Remove:
+                    if (!parent.Remove(property))
+                        throw new InvalidOperationException($"Patch remove target '{operation.Path}' does not exist.");
+                    break;
+                case PatchOperationType.Increment:
+                    parent[property] = parent.TryGetPropertyValue(property, out JsonNode current)
+                        ? Increment(current, value)
+                        : JsonSerializer.SerializeToNode(value, value.GetType());
+                    break;
+                default:
+                    throw new NotSupportedException($"Patch operation '{operation.OperationType}' is not supported by the in-memory harness.");
+            }
+        }
+
+        return root.Deserialize<T>(SerializerOptions)
+            ?? throw new InvalidOperationException("Unable to deserialize an in-memory document.");
+    }
+
+    private static JsonObject NavigateToParent(JsonNode root, IReadOnlyList<string> segments)
+    {
+        JsonNode current = root;
+        for (int index = 0; index < segments.Count - 1; index++)
+        {
+            current = current[segments[index]]
+                ?? throw new InvalidOperationException($"Patch path segment '{segments[index]}' does not exist.");
+        }
+
+        return current as JsonObject
+            ?? throw new InvalidOperationException("Patch parent must be a JSON object.");
+    }
+
+    private static JsonNode Increment(JsonNode current, object increment)
+    {
+        if (current is null || increment is null)
+            throw new InvalidOperationException("Increment requires numeric values.");
+        if (current is not JsonValue numeric)
+            throw new InvalidOperationException("Increment requires a supported numeric value.");
+
+        if (numeric.TryGetValue<int>(out int intValue))
+            return JsonValue.Create(intValue + Convert.ToInt32(increment));
+        if (numeric.TryGetValue<long>(out long longValue))
+            return JsonValue.Create(longValue + Convert.ToInt64(increment));
+        if (numeric.TryGetValue<double>(out double doubleValue))
+            return JsonValue.Create(doubleValue + Convert.ToDouble(increment));
+
+        throw new InvalidOperationException("Increment requires a supported numeric value.");
+    }
+
+    private static object PatchValue(PatchOperation operation)
+    {
+        for (Type type = operation.GetType(); type is not null; type = type.BaseType)
+        {
+            System.Reflection.PropertyInfo property = type.GetProperty(
+                "Value",
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.Public |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.DeclaredOnly);
+            if (property?.GetValue(operation) is object propertyValue)
+                return propertyValue;
+
+            foreach (System.Reflection.FieldInfo field in type.GetFields(
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.Public |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.DeclaredOnly))
+            {
+                if (field.Name.Contains("value", StringComparison.OrdinalIgnoreCase) && field.GetValue(operation) is object fieldValue)
+                    return fieldValue;
+            }
+        }
+
+        string members = string.Join(", ", operation.GetType()
+            .GetMembers(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic)
+            .Select(member => $"{member.MemberType}:{member.Name}"));
+        throw new InvalidOperationException($"Unable to read patch value from {operation.GetType().FullName}. Members: {members}");
+    }
+
+    private void UpdateMaxConcurrency(int active)
+    {
+        int observed;
+        do
+        {
+            observed = _maxConcurrentExecutions;
+            if (active <= observed)
+                return;
+        }
+        while (Interlocked.CompareExchange(ref _maxConcurrentExecutions, active, observed) != observed);
+    }
+
+    private string NextETag() => $"etag-{Interlocked.Increment(ref _etagSequence)}";
+    private static string DocumentKey(string partitionKey, string id) => $"{partitionKey}\u001f{id}";
+    private static T Clone(T model) => JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(model, SerializerOptions), SerializerOptions);
+
+    private sealed record StoredDocument(T Model, string ETag);
+
+    public override Task<ContainerResponse> ReadContainerAsync(ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ResponseMessage> ReadContainerStreamAsync(ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ContainerResponse> ReplaceContainerAsync(ContainerProperties containerProperties, ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ResponseMessage> ReplaceContainerStreamAsync(ContainerProperties containerProperties, ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ContainerResponse> DeleteContainerAsync(ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ResponseMessage> DeleteContainerStreamAsync(ContainerRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<int?> ReadThroughputAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ThroughputResponse> ReadThroughputAsync(RequestOptions requestOptions, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ThroughputResponse> ReplaceThroughputAsync(int throughput, RequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ThroughputResponse> ReplaceThroughputAsync(ThroughputProperties throughputProperties, RequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ResponseMessage> CreateItemStreamAsync(Stream streamPayload, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ResponseMessage> ReadItemStreamAsync(string id, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ResponseMessage> UpsertItemStreamAsync(Stream streamPayload, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ItemResponse<TItem>> CreateItemAsync<TItem>(TItem item, PartitionKey? partitionKey = null, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ItemResponse<TItem>> UpsertItemAsync<TItem>(TItem item, PartitionKey? partitionKey = null, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ResponseMessage> ReplaceItemStreamAsync(Stream streamPayload, string id, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ItemResponse<TItem>> ReplaceItemAsync<TItem>(TItem item, string id, PartitionKey? partitionKey = null, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<FeedResponse<TItem>> ReadManyItemsAsync<TItem>(IReadOnlyList<(string id, PartitionKey partitionKey)> items, ReadManyRequestOptions readManyRequestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ResponseMessage> ReadManyItemsStreamAsync(IReadOnlyList<(string id, PartitionKey partitionKey)> items, ReadManyRequestOptions readManyRequestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ItemResponse<TItem>> PatchItemAsync<TItem>(string id, PartitionKey partitionKey, IReadOnlyList<PatchOperation> patchOperations, PatchItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ResponseMessage> PatchItemStreamAsync(string id, PartitionKey partitionKey, IReadOnlyList<PatchOperation> patchOperations, PatchItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ItemResponse<TItem>> DeleteItemAsync<TItem>(string id, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override Task<ResponseMessage> DeleteItemStreamAsync(string id, PartitionKey partitionKey, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override FeedIterator GetItemQueryStreamIterator(QueryDefinition queryDefinition, string continuationToken = null, QueryRequestOptions requestOptions = null) => throw new NotSupportedException();
+    public override FeedIterator GetItemQueryStreamIterator(string queryText = null, string continuationToken = null, QueryRequestOptions requestOptions = null) => throw new NotSupportedException();
+    public override FeedIterator<TItem> GetItemQueryIterator<TItem>(QueryDefinition queryDefinition, string continuationToken = null, QueryRequestOptions requestOptions = null) => throw new NotSupportedException();
+    public override FeedIterator<TItem> GetItemQueryIterator<TItem>(string queryText = null, string continuationToken = null, QueryRequestOptions requestOptions = null) => throw new NotSupportedException();
+    public override FeedIterator GetItemQueryStreamIterator(FeedRange feedRange, QueryDefinition queryDefinition, string continuationToken = null, QueryRequestOptions requestOptions = null) => throw new NotSupportedException();
+    public override FeedIterator<TItem> GetItemQueryIterator<TItem>(FeedRange feedRange, QueryDefinition queryDefinition, string continuationToken = null, QueryRequestOptions requestOptions = null) => throw new NotSupportedException();
+    public override IOrderedQueryable<TItem> GetItemLinqQueryable<TItem>(bool allowSynchronousQueryExecution = false, string continuationToken = null, QueryRequestOptions requestOptions = null, CosmosLinqSerializerOptions linqSerializerOptions = null) => throw new NotSupportedException();
+    public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder<TItem>(string processorName, ChangesHandler<TItem> onChangesDelegate) => throw new NotSupportedException();
+    public override ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(string processorName, ChangesEstimationHandler estimationDelegate, TimeSpan? estimationPeriod = null) => throw new NotSupportedException();
+    public override ChangeFeedEstimator GetChangeFeedEstimator(string processorName, Container leaseContainer) => throw new NotSupportedException();
+    public override Task<IReadOnlyList<FeedRange>> GetFeedRangesAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    public override FeedIterator GetChangeFeedStreamIterator(ChangeFeedStartFrom changeFeedStartFrom, ChangeFeedMode changeFeedMode, ChangeFeedRequestOptions changeFeedRequestOptions = null) => throw new NotSupportedException();
+    public override FeedIterator<TItem> GetChangeFeedIterator<TItem>(ChangeFeedStartFrom changeFeedStartFrom, ChangeFeedMode changeFeedMode, ChangeFeedRequestOptions changeFeedRequestOptions = null) => throw new NotSupportedException();
+    public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder<TItem>(string processorName, ChangeFeedHandler<TItem> onChangesDelegate) => throw new NotSupportedException();
+    public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilderWithManualCheckpoint<TItem>(string processorName, ChangeFeedHandlerWithManualCheckpoint<TItem> onChangesDelegate) => throw new NotSupportedException();
+    public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder(string processorName, ChangeFeedStreamHandler onChangesDelegate) => throw new NotSupportedException();
+    public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilderWithManualCheckpoint(string processorName, ChangeFeedStreamHandlerWithManualCheckpoint onChangesDelegate) => throw new NotSupportedException();
+}
+
+internal sealed record InMemoryBatchExecution<T>(
+    string PartitionKey,
+    IReadOnlyList<InMemoryBatchOperation<T>> Operations,
+    bool Succeeded,
+    HttpStatusCode StatusCode,
+    double RequestCharge,
+    IReadOnlyList<InMemoryOperationOutcome> Outcomes) where T : class, ICosmicEntity;
+
+internal enum InMemoryBatchOperationKind
+{
+    Create,
+    Replace,
+    Patch,
+    Delete
+}
+
+internal sealed record InMemoryBatchOperation<T>(
+    InMemoryBatchOperationKind Kind,
+    string Id,
+    T Model,
+    string IfMatchETag,
+    IReadOnlyList<PatchOperation> PatchOperations,
+    string FilterPredicate,
+    object RequestOptions) where T : class, ICosmicEntity;
+
+internal sealed class InMemoryTransactionalBatch<T>(
+    InMemoryCosmosContainer<T> container,
+    string partitionKey) : TransactionalBatch where T : class, ICosmicEntity
+{
+    private readonly List<InMemoryBatchOperation<T>> _operations = [];
+
+    public override TransactionalBatch CreateItem<TItem>(TItem item, TransactionalBatchItemRequestOptions requestOptions = null)
+    {
+        T model = RequireModel(item);
+        _operations.Add(new(InMemoryBatchOperationKind.Create, model.id, model, null, null, null, requestOptions));
+        return this;
+    }
+
+    public override TransactionalBatch ReplaceItem<TItem>(string id, TItem item, TransactionalBatchItemRequestOptions requestOptions = null)
+    {
+        _operations.Add(new(InMemoryBatchOperationKind.Replace, id, RequireModel(item), requestOptions?.IfMatchEtag, null, null, requestOptions));
+        return this;
+    }
+
+    public override TransactionalBatch PatchItem(
+        string id,
+        IReadOnlyList<PatchOperation> patchOperations,
+        TransactionalBatchPatchItemRequestOptions requestOptions = null)
+    {
+        _operations.Add(new(InMemoryBatchOperationKind.Patch, id, null, requestOptions?.IfMatchEtag, patchOperations, requestOptions?.FilterPredicate, requestOptions));
+        return this;
+    }
+
+    public override TransactionalBatch DeleteItem(string id, TransactionalBatchItemRequestOptions requestOptions = null)
+    {
+        _operations.Add(new(InMemoryBatchOperationKind.Delete, id, null, requestOptions?.IfMatchEtag, null, null, requestOptions));
+        return this;
+    }
+
+    public override Task<TransactionalBatchResponse> ExecuteAsync(CancellationToken cancellationToken = default)
+        => container.ExecuteAsync(partitionKey, _operations, cancellationToken);
+
+    public override Task<TransactionalBatchResponse> ExecuteAsync(TransactionalBatchRequestOptions requestOptions, CancellationToken cancellationToken = default)
+        => ExecuteAsync(cancellationToken);
+
+    private static T RequireModel<TItem>(TItem item)
+        => item as T ?? throw new InvalidOperationException($"Expected a {typeof(T).Name} batch item.");
+
+    public override TransactionalBatch CreateItemStream(Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null) => throw new NotSupportedException();
+    public override TransactionalBatch ReadItem(string id, TransactionalBatchItemRequestOptions requestOptions = null) => throw new NotSupportedException();
+    public override TransactionalBatch UpsertItem<TItem>(TItem item, TransactionalBatchItemRequestOptions requestOptions = null) => throw new NotSupportedException();
+    public override TransactionalBatch UpsertItemStream(Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null) => throw new NotSupportedException();
+    public override TransactionalBatch ReplaceItemStream(string id, Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null) => throw new NotSupportedException();
+}
+
+internal sealed record InMemoryOperationOutcome(HttpStatusCode StatusCode, string ETag)
+{
+    internal bool IsSuccessStatusCode => (int)StatusCode is >= 200 and <= 299;
+}
+
+internal sealed class InMemoryTransactionalBatchResponse(
+    HttpStatusCode statusCode,
+    double requestCharge,
+    IReadOnlyList<InMemoryOperationOutcome> outcomes) : TransactionalBatchResponse
+{
+    public override bool IsSuccessStatusCode => (int)statusCode is >= 200 and <= 299;
+    public override HttpStatusCode StatusCode => statusCode;
+    public override double RequestCharge => requestCharge;
+    public override int Count => outcomes.Count;
+    public override TransactionalBatchOperationResult this[int index] => new InMemoryTransactionalBatchOperationResult(outcomes[index]);
+    public override IEnumerator<TransactionalBatchOperationResult> GetEnumerator()
+        => outcomes.Select(outcome => new InMemoryTransactionalBatchOperationResult(outcome)).GetEnumerator();
+}
+
+internal sealed class InMemoryTransactionalBatchOperationResult(
+    InMemoryOperationOutcome outcome) : TransactionalBatchOperationResult
+{
+    public override HttpStatusCode StatusCode => outcome.StatusCode;
+    public override bool IsSuccessStatusCode => outcome.IsSuccessStatusCode;
+    public override string ETag => outcome.ETag;
+}
+
+internal sealed class InMemoryItemResponse<TItem>(
+    TItem resource,
+    string eTag,
+    HttpStatusCode statusCode,
+    double requestCharge) : ItemResponse<TItem>
+{
+    public override TItem Resource => resource;
+    public override string ETag => eTag;
+    public override HttpStatusCode StatusCode => statusCode;
+    public override double RequestCharge => requestCharge;
+}

--- a/code/Universe/Interfaces/IGalaxyBasic.cs
+++ b/code/Universe/Interfaces/IGalaxyBasic.cs
@@ -9,12 +9,16 @@ public interface IGalaxyBasic<T> where T : ICosmicEntity
     /// Starts an atomic transactional batch for one logical partition.
     /// </summary>
     /// <param name="partitionKeys">Exact order of the repository partition-key values.</param>
-    AtomicBatch<T> Atomic(params string[] partitionKeys);
+    /// <remarks>The default implementation throws <see cref="NotSupportedException"/> for compatibility with implementations that predate batch operations.</remarks>
+    AtomicBatch<T> Atomic(params string[] partitionKeys)
+        => throw new NotSupportedException("This IGalaxyBasic implementation does not support atomic batch operations.");
 
     /// <summary>
     /// Starts a cross-partition bulk batch. Operations in one partition are transactional; operations across partitions are not.
     /// </summary>
-    BulkBatch<T> Bulk();
+    /// <remarks>The default implementation throws <see cref="NotSupportedException"/> for compatibility with implementations that predate batch operations.</remarks>
+    BulkBatch<T> Bulk()
+        => throw new NotSupportedException("This IGalaxyBasic implementation does not support bulk batch operations.");
 
     /// <summary>
     /// Create a new model in the database

--- a/code/Universe/UniverseQuery.csproj
+++ b/code/Universe/UniverseQuery.csproj
@@ -21,14 +21,16 @@
 		<RepositoryType>Git</RepositoryType>
 		<Authors>norarrsgd</Authors>
 		<Product>Universe</Product>
-		<Version>3.5.0-preview.1</Version>
+		<Version>3.5.0-preview.2</Version>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageReleaseNotes>
 			View release on
-			https://github.com/norarrsgd/universe/releases/tag/untagged-cdcf4202c2656450c07b
+			https://github.com/norarrsgd/universe/releases/tag/universe-3.5.0-preview.2
 		</PackageReleaseNotes>
-		<AssemblyVersion>3.5.0.1</AssemblyVersion>
-		<FileVersion>3.5.0.1</FileVersion>
+		<AssemblyVersion>3.5.0.2</AssemblyVersion>
+		<FileVersion>3.5.0.2</FileVersion>
+		<EnablePackageValidation>true</EnablePackageValidation>
+		<PackageValidationBaselineVersion>3.4.1</PackageValidationBaselineVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/code/Universe/UniverseQuery.xml
+++ b/code/Universe/UniverseQuery.xml
@@ -1382,11 +1382,13 @@
             Starts an atomic transactional batch for one logical partition.
             </summary>
             <param name="partitionKeys">Exact order of the repository partition-key values.</param>
+            <remarks>The default implementation throws <see cref="T:System.NotSupportedException"/> for compatibility with implementations that predate batch operations.</remarks>
         </member>
         <member name="M:Universe.Interfaces.IGalaxyBasic`1.Bulk">
             <summary>
             Starts a cross-partition bulk batch. Operations in one partition are transactional; operations across partitions are not.
             </summary>
+            <remarks>The default implementation throws <see cref="T:System.NotSupportedException"/> for compatibility with implementations that predate batch operations.</remarks>
         </member>
         <member name="M:Universe.Interfaces.IGalaxyBasic`1.Create(`0)">
             <summary>

--- a/docs/ROADMAP_STATUS.md
+++ b/docs/ROADMAP_STATUS.md
@@ -119,7 +119,7 @@ Preferred future direction:
 
 ### 3.1 Enhanced Bulk Operation Support
 
-Status: complete in `3.5.0-preview.1`.
+Status: complete in `3.5.0-preview.2`.
 
 Implemented:
 
@@ -130,7 +130,7 @@ Implemented:
 
 ### 3.2 Atomic Operations
 
-Status: complete in `3.5.0-preview.1`.
+Status: complete in `3.5.0-preview.2`.
 
 Implemented:
 
@@ -165,9 +165,14 @@ Remaining scope:
 
 ## Verification
 
-Current local verification for this audit:
+Transactional behavior is verified with a deterministic in-memory Cosmos harness. It covers atomic commit and rollback, ETag failures, chunking, bounded concurrency, partial success, cancellation, request options, and cache invalidation without creating or connecting to Cosmos DB resources.
+
+Current local verification:
 
 ```bash
 cd code
 dotnet test --no-restore --filter "Category!=Performance"
+dotnet pack Universe/UniverseQuery.csproj -c Release --no-restore
 ```
+
+Release packing validates the public package API against `UniverseQuery` `3.4.1`.

--- a/docs/ROADMAP_STATUS.md
+++ b/docs/ROADMAP_STATUS.md
@@ -171,7 +171,7 @@ Current local verification:
 
 ```bash
 cd code
-dotnet test --no-restore --filter "Category!=Performance"
+dotnet test -c Release --no-restore --filter "Category!=Performance"
 dotnet pack Universe/UniverseQuery.csproj -c Release --no-restore
 ```
 


### PR DESCRIPTION
## Summary
- Preserve legacy IGalaxyBasic implementations with default unsupported batch methods and validate package compatibility against 3.4.1.
- Add deterministic in-memory transactional coverage for rollback, ETags, chunking, concurrency, partial success, cancellation, request options, and cache invalidation.
- Harden beta and prod NuGet publication gates and update preview.2 package metadata and release documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support validation for atomic and bulk batch operations, including rollback, concurrency, chunking, cancellation, and partial success scenarios.
  * Improved compatibility for existing implementations that do not support batch operations; unsupported operations now return clear errors.

* **Documentation**
  * Updated testing, roadmap, and release documentation with expanded batch-operation coverage and validation details.

* **Release**
  * Updated the package to version 3.5.0-preview.2 with enhanced package validation and publishing safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->